### PR TITLE
docs: record why the client half cannot be split (#7)

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -27,6 +27,35 @@
  * renders — so the panel and the command have no second aggregation to drift
  * apart, and "the numbers match the command" is a meaningful test.
  *
+
+ * ## Why this is one file, and has to stay one
+ *
+ * It is long — CSS, both dictionaries, every component, the data hooks. That
+ * looks like a file begging to be split, and it cannot be. Checked against
+ * `dsh-client-modules` rather than assumed:
+ *
+ * - The host resolves `exports["./client"]` to **one** path, reads it with
+ *   `readFileSync`, and serves it as-is (`lib/index.js`). There is no bundler
+ *   in the path, so one graph row is one URL is one file.
+ * - The synchronous `require` handed to a factory resolves seed words, shell
+ *   modules, and **already-registered factories** — it has no load branch,
+ *   because loading is async (`lib/client.js`, `makeRequire`). A sibling file
+ *   nothing fetched can therefore never be required; the panel would die at
+ *   materialization.
+ *
+ * Two `load()` calls inside *this* file would work — `factories` is keyed only
+ * by what was registered, with no boot-graph check — but that splits nothing.
+ *
+ * One thing that would break even then: `claimStyles` tags untagged `<style>`
+ * elements with whichever id is materializing, for HMR bookkeeping. Injecting
+ * the stylesheet from a child module would file it under the child, and
+ * invalidating the panel would leave the stylesheet behind. The injection
+ * belongs to the factory whose id owns it.
+ *
+ * A build step would dissolve all of this, and cost the property this file is
+ * shaped around: with no toolchain, the browser half can be materialized and
+ * tested in Node, which is what `test/client.test.js` does.
+ *
  * @module dsh-tokenledger/client
  */
 


### PR DESCRIPTION
Closes #7 — as **won't fix**, with the evidence, rather than by splitting.

### What was tried

Extracting the two dictionaries (156 lines of data, the largest thing between a reader and the components) into a sibling `__ModuleLoader__` module, keeping the CSS where it is.

### Why it cannot work

Checked against the real `dsh-client-modules` in a local DSH install, not assumed:

| Where | What it does |
| --- | --- |
| `lib/index.js` | Resolves `exports["./client"]` to **one** path, `readFileSync`, serves it as-is. No bundler — one graph row is one URL is one file. |
| `lib/client.js` → `makeRequire` | Resolves seed words, shell modules, and **already-registered factories**. No load branch, because loading is async. |

Together those close the door: a sibling file that nothing fetches can never be required, so `require("dsh-tokenledger/strings")` throws at materialization and the panel dies — silently, which is the failure mode this project has already paid for several times.

Two `load()` calls inside `client.js` itself *would* resolve — `factories` is keyed purely by what registered, with no boot-graph check — but that splits nothing.

### A trap found on the way

`claimStyles` tags untagged `<style>` elements with whichever id is materializing, for HMR bookkeeping. Had the CSS moved into a child module, the stylesheet would be filed under the child's id, and invalidating the panel would leave it behind. Worth knowing independently of this issue.

### What this PR actually changes

Documentation only — the module docstring now carries the above, so the next person to look at a 1600-line file and reach for the obvious fix finds out why it is not one. No behaviour change; 260 tests pass.

A build step would dissolve the whole constraint, and cost the property the file is shaped around: with no toolchain, the browser half materializes and tests in Node, which is exactly what `test/client.test.js` does. That trade is a real decision and does not belong in a cleanup issue.