### PR TITLE
fix: 鉴权失败返回 HTTP 200 的供应商不再被读成空账户

### DIFF
--- a/src/balance.js
+++ b/src/balance.js
@@ -30,6 +30,15 @@
  * with no balance endpoint: each says so in words. A red state belongs on a
  * problem, and none of those is one.
  *
+ * ## A 200 is not a yes
+ *
+ * Some vendors answer every request with HTTP 200 and put the refusal in the
+ * body. Z.ai does it even for a path that does not exist, so its status code
+ * carries no information at all. Reading only `response.ok` there parses the
+ * refusal as data, finds none of the fields it wanted, and renders a card that
+ * says the account is empty — which is the one thing this module promises never
+ * to do. A scheme whose vendor works that way declares an `envelope`.
+ *
  * @module dsh-tokenledger/balance
  */
 
@@ -182,6 +191,19 @@ export const SCHEMES = {
 
 	zai: {
 		label: "Z.ai",
+		// Auth here happens before routing: a bad key gets HTTP 200 and
+		// `{"code":401,"msg":"token expired or incorrect","success":false}`, and
+		// so does a path that was never served. The status line is therefore
+		// worthless and the body is the only place the answer lives.
+		envelope: (body) => {
+			// `success` is the explicit signal. `code` only supplies the number,
+			// and only when it disagrees with both success conventions — a live
+			// account must never be reported as refused because its success code
+			// was spelled 0 rather than 200.
+			const code = typeof body?.code === "number" ? body.code : undefined;
+			const refused = body?.success === false || (code !== undefined && code !== 0 && code !== 200);
+			return refused ? { status: code, message: typeof body?.msg === "string" ? body.msg : undefined } : undefined;
+		},
 		async read({ origin, get, vendor }) {
 			const body = await get(new URL("/api/paas/v4/balance", origin).href);
 			const data = body?.data;
@@ -296,18 +318,31 @@ export async function readBalance(options = {}) {
 			signal: controller.signal
 		});
 		if (!response.ok) throw Object.assign(new Error(`http-${response.status}`), { status: response.status });
-		return response.json();
+		const body = await response.json();
+		// Run before the reader sees it, so a refusal can never be mistaken for a
+		// response whose fields all happen to be missing.
+		const refusal = spec.envelope?.(body);
+		if (refusal === undefined) return body;
+		throw Object.assign(new Error(refusal.message ?? `upstream-${refusal.status ?? "error"}`), {
+			status: refusal.status,
+			// Distinguishes "the vendor said no in the body" from "the transport
+			// said no in the status line". Both are failures; only one of them
+			// means the status code meant anything.
+			fromEnvelope: true
+		});
 	};
 
 	try {
 		return { supported: true, fetched: true, scheme, ...(await spec.read({ origin, get, vendor: vendorOf(origin) })) };
 	} catch (error) {
 		const reason =
-			error?.status !== undefined
-				? `http-${error.status}`
-				: error?.name === "AbortError"
-					? "timeout"
-					: "unreachable";
+			error?.fromEnvelope === true
+				? `upstream-${error.status ?? "error"}`
+				: error?.status !== undefined
+					? `http-${error.status}`
+					: error?.name === "AbortError"
+						? "timeout"
+						: "unreachable";
 		// A scheme whose endpoint wants a different credential from the one the
 		// route carries says so, rather than leaving the card on a bare 401 that
 		// reads as "your key is wrong".

--- a/test/balance.test.js
+++ b/test/balance.test.js
@@ -29,6 +29,7 @@ test("every scheme answers the same shape, so one card renders all of them", () 
 	for (const [name, spec] of Object.entries(SCHEMES)) {
 		assert.equal(typeof spec.read, "function", name);
 		assert.equal(typeof spec.label, "string", name);
+		if (spec.envelope !== undefined) assert.equal(typeof spec.envelope, "function", name);
 	}
 });
 
@@ -550,6 +551,87 @@ test("zai reads available against total", async () => {
 	assert.equal(result.total, 64);
 	assert.equal(result.granted, 100);
 	assert.equal(result.currency, "CNY");
+});
+
+// --- vendors that refuse with a 200 ------------------------------------------
+//
+// Probed live with an invalid Bearer and a control path that does not exist:
+//
+//   GET https://api.z.ai/api/monitor/usage/quota/limit
+//     -> 200 {"code":401,"msg":"token expired or incorrect","success":false}
+//   GET https://api.z.ai/api/monitor/nope-404            (control)
+//     -> 200 {"code":401,"msg":"token expired or incorrect","success":false}
+//
+// The control is the point: the status line does not even distinguish a route
+// that exists from one that never did, so nothing can be read off it.
+
+test("a refusal dressed as a 200 is a failure, not an empty account", async () => {
+	const result = await readBalance({
+		scheme: "zai",
+		origin: "https://api.z.ai",
+		apiKey: "bad-key",
+		fetch: okJson({ code: 401, msg: "token expired or incorrect", success: false })
+	});
+	assert.equal(result.fetched, false, "the vendor refused; nothing was read");
+	assert.equal(result.reason, "upstream-401");
+	assert.equal(result.total, undefined, "an account we could not read has no balance to report");
+	assert.equal(result.isAvailable, undefined);
+});
+
+test("an envelope refusal reads differently from a transport failure", async () => {
+	// Both are failures, and they are not the same failure: one means the vendor
+	// answered and said no, the other means the status line said no. Collapsing
+	// them loses the only thing that tells you the endpoint is even alive.
+	const envelope = await readBalance({
+		scheme: "zai",
+		origin: "https://api.z.ai",
+		apiKey: "k",
+		fetch: okJson({ success: false, msg: "nope" })
+	});
+	const transport = await readBalance({
+		scheme: "zai",
+		origin: "https://api.z.ai",
+		apiKey: "k",
+		fetch: async () => ({ ok: false, status: 401 })
+	});
+	assert.equal(envelope.reason, "upstream-error", "no code in the body means no number to report");
+	assert.equal(transport.reason, "http-401");
+});
+
+test("a success code spelled 0 is still a success", async () => {
+	// The refusal signal is `success:false`; `code` only supplies the number.
+	// Reading any non-200 code as a refusal would report a live account as
+	// unreadable on every vendor that spells success `0`, which is common.
+	const result = await readBalance({
+		scheme: "zai",
+		origin: "https://api.z.ai",
+		apiKey: "k",
+		fetch: okJson({ code: 0, data: { total_balance: 100, available_balance: 64 } })
+	});
+	assert.equal(result.fetched, true);
+	assert.equal(result.total, 64);
+});
+
+test("a vendor that carries neither convention is left alone", async () => {
+	// `/api/paas/v4/balance` may answer with a bare `data` object. An envelope
+	// that fires on absence would break every such response.
+	const result = await readBalance({
+		scheme: "zai",
+		origin: "https://api.z.ai",
+		apiKey: "k",
+		fetch: okJson({ data: { total_balance: 10, available_balance: 10 } })
+	});
+	assert.equal(result.fetched, true);
+	assert.equal(result.total, 10);
+});
+
+test("schemes whose vendor uses real status codes gain no envelope", async () => {
+	// DeepSeek, Moonshot, OpenRouter and New API all answer 401 with a 401. A
+	// blanket envelope check would start rejecting their success bodies for
+	// carrying an unrelated `code` field.
+	for (const scheme of ["deepseek", "moonshot", "openrouter", "newapi", "sub2api"]) {
+		assert.equal(SCHEMES[scheme].envelope, undefined, scheme);
+	}
 });
 
 test("a vendor response missing every field fails soft, with no zeros invented", async () => {


### PR DESCRIPTION
Closes #9.

## 改了什么

`readBalance` 的 `get()` 在 `response.json()` 之后、把响应交给 scheme 的 `read()` 之前，多跑一个可选的 `spec.envelope(body)`。返回了拒绝描述就抛错，走和 HTTP 错误一样的失败路径；返回 `undefined` 就原样放行。

目前只有 `zai` 声明了 envelope，因为只有它被实测证实是这个形状。

## 为什么 `success` 是信号，`code` 不是

探测结果（无效 Bearer + 一个不存在的路径做对照）：

```
GET https://api.z.ai/api/monitor/usage/quota/limit
  -> 200 {"code":401,"msg":"token expired or incorrect","success":false}
GET https://api.z.ai/api/monitor/nope-404          (对照)
  -> 200 {"code":401,"msg":"token expired or incorrect","success":false}
GET https://open.bigmodel.cn/api/monitor/usage/quota/limit
  -> 200 {"code":401,"msg":"令牌已过期或验证不正确","success":false}
```

对照那一行是关键：**连路由存不存在都分辨不出来**，所以状态码里没有任何可读的信息。

判定条件写成"`success === false`，或者 `code` 是个既不是 0 也不是 200 的数字"。把"`code !== 200` 就是失败"当规则会出事——很多接口用 `code: 0` 表示成功，那样会把一个活着的账户报成读不出来，比现在的 bug 更糟。有一个测试专门守这一条。

## 失败原因分成两种

`upstream-<code>`（上游答了话，说的是拒绝）和 `http-<code>`（状态行就说了不行）分开。两者都是失败，但只有后者意味着状态码有意义；混成一个就看不出端点是不是还活着。卡片上的 `reason` 是插值渲染的，不需要新文案。

## 测试

`test/balance.test.js` +5：

- 200 + `{success:false, code:401}` → `fetched:false`、`reason:"upstream-401"`、`total` 缺席（**不是** 0）
- envelope 失败与传输失败的 `reason` 不同
- `code: 0` + 正常 data → 照常读出余额
- 两种约定都不带的响应体 → envelope 不介入（`/api/paas/v4/balance` 可能就是这样）
- 用真实状态码的五个 scheme 断言**没有** envelope，防止以后有人图省事加个全局检查

265 个测试全绿。

## 没做的

MiniMax 的 `base_resp.status_code` 是同一类形状（四个主机全部 200 + `status_code:1004`，而它的 404 对照是真的 404），但 MiniMax 还没有 scheme，现在加就是一段没人调用的代码。它跟着 #12 一起进来。
