### PR TITLE
fix: 浮层改用 overlay 底色令牌，透明质感皮肤下不再穿透

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -139,7 +139,14 @@ window.__ModuleLoader__.load({
 			".tkl_layer.tkl_rail .tkl_badgeLabel,.tkl_layer.tkl_rail .tkl_badgeValue{display:none}",
 
 			// -- the panel ---------------------------------------------------------
-			".tkl_panel{z-index:30;box-sizing:border-box;border:1px solid var(--dsw-alias-border-l1);background:var(--dsw-alias-bg-base);width:460px;max-width:calc(100vw - 24px);max-height:76vh;box-shadow:var(--dsw-shadow-lv2);border-radius:12px;flex-direction:column;display:flex;position:fixed;bottom:128px;left:12px;overflow:hidden;" +
+			//
+			// Everything that floats reaches for `--dsw-alias-bg-overlay` first.
+			// `--dsw-alias-bg-base` is the PAGE's ground, and a skin that wants a
+			// frosted look sets it to `transparent` — correct for the page, fatal
+			// for a panel sitting on top of it, which then shows the wallpaper
+			// through its own text. Themes that define no overlay token fall back
+			// to the old value, so the default look is unchanged.
+			".tkl_panel{z-index:30;box-sizing:border-box;border:1px solid var(--dsw-alias-border-l1);background:var(--dsw-alias-bg-overlay,var(--dsw-alias-bg-base));width:460px;max-width:calc(100vw - 24px);max-height:76vh;box-shadow:var(--dsw-shadow-lv2);border-radius:12px;flex-direction:column;display:flex;position:fixed;bottom:128px;left:12px;overflow:hidden;" +
 				// Scoped here rather than on :root so nothing escapes into the host.
 				"--dsh-scrollbar-thumb:var(--dsw-alias-scrollbar-bg-l2);--dsh-scrollbar-thumb-hover:var(--dsw-alias-scrollbar-hover-l2);" +
 				"--tkl-radius:12px;--tkl-radius-sm:8px;--tkl-radius-xs:6px;" +
@@ -155,7 +162,7 @@ window.__ModuleLoader__.load({
 			"[data-theme='dark'] .tkl_panel{--tkl-level-1:#065f46;--tkl-level-2:#059669;--tkl-level-3:#10b981;--tkl-level-4:#34d399;--tkl-direct:#6b7280;--tkl-series-0:#38bdf8;--tkl-series-1:#fbbf24;--tkl-series-2:#a78bfa;--tkl-series-3:#2dd4bf;--tkl-series-4:#f472b6;--tkl-series-5:#a3e635}",
 			"[data-theme='light'] .tkl_panel{--tkl-level-1:#a7f3d0;--tkl-level-2:#6ee7b7;--tkl-level-3:#34d399;--tkl-level-4:#10b981;--tkl-direct:#8b93a7;--tkl-series-0:#0ea5e9;--tkl-series-1:#f59e0b;--tkl-series-2:#8b5cf6;--tkl-series-3:#14b8a6;--tkl-series-4:#ec4899;--tkl-series-5:#84cc16}",
 
-			".tkl_header{box-sizing:border-box;border-bottom:1px solid var(--dsw-alias-border-l2);background:var(--dsw-alias-bg-base);flex:none;justify-content:space-between;align-items:center;min-height:44px;padding:10px 12px;display:flex;gap:8px}",
+			".tkl_header{box-sizing:border-box;border-bottom:1px solid var(--dsw-alias-border-l2);background:var(--dsw-alias-bg-overlay,var(--dsw-alias-bg-base));flex:none;justify-content:space-between;align-items:center;min-height:44px;padding:10px 12px;display:flex;gap:8px}",
 			".tkl_headerLeft{align-items:center;gap:8px;display:flex;min-width:0}",
 			".tkl_title{color:var(--dsw-alias-label-primary);font-size:13px;font-weight:500;line-height:20px;white-space:nowrap}",
 			".tkl_headerActions{align-items:center;gap:2px;display:flex;flex:none}",
@@ -248,7 +255,9 @@ window.__ModuleLoader__.load({
 			// a second of hovering and nothing else. The panel already has the
 			// per-model split for that day, so showing it is nearly free and turns
 			// the strip from decoration into something you read.
-			".tkl_tip{position:fixed;z-index:40;pointer-events:none;min-width:180px;max-width:250px;background:var(--dsw-alias-bg-base);border:1px solid var(--dsw-alias-border-l2);border-radius:var(--tkl-radius-sm);box-shadow:var(--dsw-shadow-lv2);padding:8px 10px}",
+			// The tooltip floats over the panel's own content, so it needs an
+			// opaque ground even more than the panel does.
+			".tkl_tip{position:fixed;z-index:40;pointer-events:none;min-width:180px;max-width:250px;background:var(--dsw-alias-bg-overlay,var(--dsw-alias-bg-base));border:1px solid var(--dsw-alias-border-l2);border-radius:var(--tkl-radius-sm);box-shadow:var(--dsw-shadow-lv2);padding:8px 10px}",
 			".tkl_tipHead{display:flex;align-items:center;gap:6px;justify-content:space-between}",
 			".tkl_tipDate{color:var(--dsw-alias-label-secondary);font-size:11px;line-height:16px;font-variant-numeric:tabular-nums}",
 			".tkl_tipLevel{color:var(--dsw-alias-label-tertiary);font-size:10px;line-height:14px;border:1px solid var(--dsw-alias-border-l2);border-radius:999px;padding:0 6px;flex:none}",

--- a/test/client.test.js
+++ b/test/client.test.js
@@ -147,8 +147,42 @@ test("styles are injected once, tagged so a re-execution can find them", async (
 	assert.ok(tag.textContent.includes(".tkl_panel"));
 	// Every colour must come from a DSH token or a scoped --tkl-* value, or the
 	// panel will not follow the user's theme.
-	assert.ok(tag.textContent.includes("var(--dsw-alias-bg-base)"));
+	assert.ok(tag.textContent.includes("var(--dsw-alias-bg-overlay,var(--dsw-alias-bg-base))"));
 	assert.ok(tag.textContent.includes("var(--dsw-alias-border-l1)"));
+});
+
+test("everything that floats asks for the overlay ground, with the page ground as fallback", async () => {
+	// `--dsw-alias-bg-base` is the PAGE's ground. A skin that wants a frosted
+	// look sets it to `transparent`, which is right for the page and fatal for
+	// anything floating above it: the panel then shows the wallpaper through its
+	// own text. The failure is invisible to us because the default theme leaves
+	// both tokens opaque, so only a test keeps this from being reverted by the
+	// next person who reaches for the token they see everywhere else.
+	const { dom } = await loadBundle();
+	const css = dom.head.children[0].textContent;
+
+	for (const selector of ["tkl_panel", "tkl_header", "tkl_tip"]) {
+		const rule = css.match(new RegExp(`\\.${selector}\\{[^}]*\\}`))[0];
+		assert.match(
+			rule,
+			/background:var\(--dsw-alias-bg-overlay,var\(--dsw-alias-bg-base\)\)/,
+			`.${selector} floats, so it must not paint itself with the page's ground`
+		);
+	}
+
+	// The fallback is the whole point: a theme defining no overlay token has to
+	// render exactly as it did before.
+	assert.equal(
+		/background:var\(--dsw-alias-bg-base\)/.test(css),
+		false,
+		"a bare page-ground background is the bug; every one of them must carry the overlay fallback"
+	);
+
+	// Elements that sit INSIDE the panel are a different case — they inherit its
+	// ground and must stay transparent, or they paint an opaque rectangle over
+	// a skin's own texture.
+	assert.match(css.match(/\.tkl_badge\{[^}]*\}/)[0], /background:0 0/, "the sidebar badge belongs to the sidebar");
+	assert.match(css.match(/\.tkl_select\{[^}]*\}/)[0], /background:0 0/, "the picker sits on the panel's ground");
 });
 
 test("the activity ramp is defined for both themes and for an explicit choice", async () => {


### PR DESCRIPTION
Closes #10.

## 改了什么

三条规则的背景由 `var(--dsw-alias-bg-base)` 改成 `var(--dsw-alias-bg-overlay,var(--dsw-alias-bg-base))`：

- `.tkl_panel` —— 面板本体
- `.tkl_header` —— 面板标题栏
- `.tkl_tip` —— 热力图的悬浮提示

`--dsw-alias-bg-base` 是**页面底色**。皮肤要做毛玻璃观感时会把它设成 `transparent`，这对页面是对的，对浮在页面之上的面板是灾难——文字直接压在壁纸上。浮层有自己的令牌，皮肤会把那个保持不透明。

带回退写法，所以没定义 overlay 令牌的主题（含默认主题）渲染零变化。

## 没改什么（这部分是重点）

「把所有 `bg-base` 换掉」是这个 issue 最容易犯的错。**嵌在面板里的元素必须保持透明**，否则它们会在皮肤的纹理上糊一块不透明矩形：

- `.tkl_badge` —— 坐在侧栏里，跟随侧栏底色（本来就是 `background:0 0`）
- `.tkl_select` —— 账户选择器，坐在面板自己的底色上（本来就是 `background:0 0`）

测试把这两条也断言住了，免得下次有人顺手"统一"掉。

## 测试

`test/client.test.js` +1，四组断言：

1. 三个浮层各自的规则里带 overlay + 回退
2. 整份样式表里**不存在**裸的 `background:var(--dsw-alias-bg-base)` —— 漏掉一个就等于 bug 还在
3. 徽章仍然透明
4. 选择器仍然透明

第 2 条是防漏的那条：默认主题下这个 bug 完全不可见，我们自己看不出来，只能靠测试守。

266 个测试全绿。
