### PR TITLE
feat: 订阅计划的滚动配额窗口——数据模型与卡片渲染

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "./package.json": "./package.json",
     "./plugin": "./src/plugin.js",
     "./pricing": "./src/pricing.js",
+    "./quota": "./src/quota.js",
     "./relay-sites": "./src/relay-sites.js",
     "./report": "./src/report.js",
     "./store": "./src/store.js",

--- a/src/balance.js
+++ b/src/balance.js
@@ -43,6 +43,7 @@
  */
 
 import { detectRelaySoftware } from "./adapters/detect.js";
+import { normalizeWindows } from "./quota.js";
 import { normalizeOrigin } from "./relay-sites.js";
 
 /** The vendor's own endpoint, and the only origin the `deepseek` scheme calls. */
@@ -129,10 +130,19 @@ function toNumber(value) {
  * One reader per relay program, plus the vendor.
  *
  * Each returns the same shape so the panel renders one card whatever answered:
- * `{ currency, total, granted, used, unlimited?, plan?, note? }`, with every
- * field absent rather than zeroed when the response does not carry it. A
- * balance of nothing and an unreported balance are different facts, and showing
- * the second as the first tells someone their account is empty.
+ * `{ currency, total, granted, used, unlimited?, plan?, windows?, note? }`,
+ * with every field absent rather than zeroed when the response does not carry
+ * it. A balance of nothing and an unreported balance are different facts, and
+ * showing the second as the first tells someone their account is empty.
+ *
+ * The card has two halves and they are not alternatives. `total` and friends
+ * are money; `windows` is a subscription's rolling allowances (see `quota.js`).
+ * An account can have both — a plan with a top-up wallet behind it is ordinary
+ * — so what is rendered is decided by which fields are present, never by a mode
+ * flag that would force a choice reality does not make.
+ *
+ * A reader returns windows in whatever unit its vendor speaks; `readBalance`
+ * normalizes them.
  */
 export const SCHEMES = {
 	deepseek: {
@@ -293,7 +303,9 @@ export const SCHEMES = {
 /**
  * Read one account.
  *
- * @param options - `{ scheme, origin, apiKey, fetch?, timeoutMs? }`.
+ * @param options - `{ scheme, origin, apiKey, fetch?, timeoutMs?, now? }`.
+ *   `now` is only used to resolve relative reset times into instants, and is
+ *   injectable so a test does not have to race the clock.
  * @returns `{ supported, fetched, ... }`. `fetched` rather than `ok` because
  *   the caller wraps this in an envelope whose own `ok` means "the request was
  *   served"; spreading one over the other made a served request that simply had
@@ -333,7 +345,17 @@ export async function readBalance(options = {}) {
 	};
 
 	try {
-		return { supported: true, fetched: true, scheme, ...(await spec.read({ origin, get, vendor: vendorOf(origin) })) };
+		const read = await spec.read({ origin, get, vendor: vendorOf(origin) });
+		// Normalized here rather than in each reader, so a scheme describes what
+		// its vendor sent ("a ratio", "seconds from now") and never has to get
+		// the arithmetic right a fifth time. `windows` stays absent when there
+		// are none — an empty array would claim a subscription with nothing in
+		// it, which is the same lie as reporting an unread balance as zero.
+		const result = { supported: true, fetched: true, scheme, ...read };
+		const windows = normalizeWindows(read.windows, { now: options.now ?? Date.now() });
+		if (windows === undefined) delete result.windows;
+		else result.windows = windows;
+		return result;
 	} catch (error) {
 		const reason =
 			error?.fromEnvelope === true

--- a/src/client.js
+++ b/src/client.js
@@ -285,13 +285,37 @@ window.__ModuleLoader__.load({
 			".tkl_sortMark{color:var(--dsw-alias-label-secondary);margin-left:2px}",
 
 			// -- balance -----------------------------------------------------------
-			".tkl_balance{border:1px solid var(--dsw-alias-border-l2);border-radius:var(--tkl-radius-sm);padding:9px 11px;display:flex;align-items:center;gap:8px}",
+			// The card is a column so quota windows can stack under the amount.
+			// With no windows it holds a single child, the gap never applies, and
+			// the row renders exactly as it did before they existed.
+			".tkl_balance{border:1px solid var(--dsw-alias-border-l2);border-radius:var(--tkl-radius-sm);padding:9px 11px;display:flex;flex-direction:column;gap:9px}",
+			".tkl_balanceTop{display:flex;align-items:center;gap:8px}",
 			".tkl_balanceMain{min-width:0}",
 			".tkl_balanceWho{color:var(--dsw-alias-label-tertiary);font-size:11px;line-height:16px}",
 			".tkl_balanceOk{color:var(--dsw-alias-state-success-primary)}",
 			".tkl_balanceBad{color:var(--dsw-alias-state-warn-primary)}",
 			".tkl_balanceAmount{color:var(--dsw-alias-label-primary);font-size:16px;line-height:22px;font-weight:600;font-variant-numeric:tabular-nums}",
 			".tkl_balanceMeta{color:var(--dsw-alias-label-tertiary);font-size:11px;line-height:16px;margin-left:auto;text-align:right}",
+
+			// -- quota windows -------------------------------------------------------
+			// A subscription's allowances: one row per window, each naming itself,
+			// when it next empties, and how full it is. The percentage sits beside
+			// the bar rather than inside it, so the state is legible without
+			// relying on the fill colour — the colour is a second channel, never
+			// the only one.
+			".tkl_wins{display:flex;flex-direction:column;gap:7px}",
+			".tkl_win{display:flex;flex-direction:column;gap:3px}",
+			".tkl_winHead{display:flex;align-items:baseline;gap:6px;min-width:0}",
+			".tkl_winName{color:var(--dsw-alias-label-secondary);font-size:11px;line-height:16px;white-space:nowrap}",
+			".tkl_winReset{color:var(--dsw-alias-label-caption);font-size:10px;line-height:16px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}",
+			".tkl_winPct{color:var(--dsw-alias-label-primary);font-size:11px;line-height:16px;font-variant-numeric:tabular-nums;margin-left:auto;flex:none}",
+			".tkl_winBar{height:4px;border-radius:999px;background:var(--tkl-level-0);overflow:hidden}",
+			// The three states reuse DSH's own state tokens rather than inventing
+			// colours, so they follow whatever the active theme or skin decided
+			// those states should look like.
+			".tkl_winFill{height:100%;border-radius:999px;background:var(--dsw-alias-state-success-primary)}",
+			".tkl_winFill.tkl_winWarn{background:var(--dsw-alias-state-warn-primary)}",
+			".tkl_winFill.tkl_winFull{background:var(--dsw-alias-state-error-primary)}",
 
 			// -- footer ------------------------------------------------------------
 			".tkl_footer{color:var(--dsw-alias-label-caption);border-top:1px solid var(--dsw-alias-border-l1);margin-top:14px;padding-top:8px;font-size:11px;line-height:16px;font-variant-numeric:tabular-nums}",
@@ -380,12 +404,23 @@ window.__ModuleLoader__.load({
 			hit: "tkl_hit",
 			sortMark: "tkl_sortMark",
 			balance: "tkl_balance",
+			balanceTop: "tkl_balanceTop",
 			balanceMain: "tkl_balanceMain",
 			balanceWho: "tkl_balanceWho",
 			balanceOk: "tkl_balanceOk",
 			balanceBad: "tkl_balanceBad",
 			balanceAmount: "tkl_balanceAmount",
 			balanceMeta: "tkl_balanceMeta",
+			wins: "tkl_wins",
+			win: "tkl_win",
+			winHead: "tkl_winHead",
+			winName: "tkl_winName",
+			winReset: "tkl_winReset",
+			winPct: "tkl_winPct",
+			winBar: "tkl_winBar",
+			winFill: "tkl_winFill",
+			winWarn: "tkl_winWarn",
+			winFull: "tkl_winFull",
 			footer: "tkl_footer",
 			warn: "tkl_warn",
 			skel: "tkl_skel",
@@ -1051,6 +1086,99 @@ window.__ModuleLoader__.load({
 		}
 
 		/**
+		 * What to call one window.
+		 *
+		 * `minutes` is consulted only for `session`, because it is the only kind
+		 * whose own name says nothing about how long it is — one plan's rolling
+		 * window is five hours, another's is three, and a `session` row labelled
+		 * "5 hours" on both would be a number the panel made up. `weekly` and
+		 * `monthly` already state their period, so a length would only repeat it.
+		 */
+		function windowLabel(window, translate) {
+			if (window.kind === "session" && typeof window.minutes === "number") {
+				const minutes = window.minutes;
+				if (minutes % 1440 === 0) return translate("balance.window.days", { n: minutes / 1440 });
+				if (minutes % 60 === 0) return translate("balance.window.hours", { n: minutes / 60 });
+				return translate("balance.window.minutes", { n: minutes });
+			}
+			return translate(`balance.window.${window.kind}`);
+		}
+
+		/**
+		 * A subscription's rolling allowances.
+		 *
+		 * These accounts hold no money — several independent windows fill up and
+		 * empty on their own clocks, and "how much of the current one is left" is
+		 * the question the panel exists to answer. Rendered under the amount
+		 * rather than instead of it: a plan with a wallet behind it has both.
+		 */
+		function QuotaWindows({ windows, translate }) {
+			if (!Array.isArray(windows) || windows.length === 0) return null;
+			return jsx("div", {
+				className: S.wins,
+				children: windows.map((window) => {
+					const used = window.usedPercent;
+					const known = typeof used === "number";
+					// Three bands, and the number is always spelled out beside the
+					// bar — the colour repeats the state, it does not carry it.
+					const tone = !known || used < 75 ? "" : used >= 100 ? ` ${S.winFull}` : ` ${S.winWarn}`;
+					return jsxs("div", {
+						className: S.win,
+						children: [
+							jsxs("div", {
+								className: S.winHead,
+								children: [
+									jsx("span", { className: S.winName, children: windowLabel(window, translate) }),
+									window.resetsAt === undefined
+										? null
+										: jsx("span", {
+												className: S.winReset,
+												children: translate("balance.window.reset", { at: fmtReset(window.resetsAt) })
+											}),
+									jsx("span", {
+										className: S.winPct,
+										children: window.unlimited === true
+											? translate("balance.window.unlimited")
+											: known
+												? translate("balance.window.used", { pct: String(used) })
+												: "—"
+									})
+								]
+							}),
+							// An unlimited window has no fraction to draw, and a bar
+							// stuck at zero would read as "none used of a finite
+							// allowance" — the opposite of what it means.
+							window.unlimited === true || !known
+								? null
+								: jsx("div", {
+										className: S.winBar,
+										role: "progressbar",
+										"aria-valuenow": used,
+										"aria-valuemin": 0,
+										"aria-valuemax": 100,
+										"aria-label": windowLabel(window, translate),
+										children: jsx("div", { className: `${S.winFill}${tone}`, style: { width: `${used}%` } })
+									})
+						]
+					});
+				})
+			});
+		}
+
+		/**
+		 * A reset instant, to the minute.
+		 *
+		 * Rendered in the viewer's own locale and zone rather than the vendor's:
+		 * the question is "when does this free up for me", and an instant printed
+		 * in someone else's timezone answers a different one.
+		 */
+		function fmtReset(iso) {
+			const date = new Date(iso);
+			if (Number.isNaN(date.getTime())) return iso;
+			return date.toLocaleString(undefined, { month: "numeric", day: "numeric", hour: "2-digit", minute: "2-digit" });
+		}
+
+		/**
 		 * One account's balance, whatever software serves it.
 		 *
 		 * Every scheme returns the same shape, so this renders DeepSeek, New API
@@ -1116,6 +1244,9 @@ window.__ModuleLoader__.load({
 				className: S.balance,
 				children: [
 					jsxs("div", {
+						className: S.balanceTop,
+						children: [
+					jsxs("div", {
 						className: S.balanceMain,
 						children: [
 							// Name the vendor AND the software. "Official balance"
@@ -1147,6 +1278,11 @@ window.__ModuleLoader__.load({
 							notes.length === 0 ? null : jsx("div", { children: notes.join(" · " ) })
 						]
 					})
+						]
+					}),
+					// Under the amount, not instead of it. An account can hold both
+					// a wallet and a plan, and the card has to be able to say so.
+					jsx(QuotaWindows, { windows: balance.windows, translate })
 				]
 			});
 		}
@@ -1474,6 +1610,16 @@ window.__ModuleLoader__.load({
 			"balance.active": "账户可用",
 			"balance.inactive": "账户不可用",
 			"balance.granted": "其中赠送 {amount}",
+			"balance.window.session": "当前窗口",
+			"balance.window.weekly": "每周窗口",
+			"balance.window.monthly": "每月窗口",
+			"balance.window.billing": "计费周期",
+			"balance.window.hours": "{n} 小时窗口",
+			"balance.window.days": "{n} 天窗口",
+			"balance.window.minutes": "{n} 分钟窗口",
+			"balance.window.reset": "{at} 重置",
+			"balance.window.used": "已用 {pct}%",
+			"balance.window.unlimited": "不限量",
 			"balance.noRoute": "没有直连 DeepSeek 官方的路由——中转站没有余额接口。",
 			"balance.unavailable": "这个部署问不到 provider 配置。",
 			"footer.updated": "{ago}从会话日志读取",
@@ -1552,6 +1698,16 @@ window.__ModuleLoader__.load({
 			"balance.active": "Account active",
 			"balance.inactive": "Account inactive",
 			"balance.granted": "{amount} granted",
+			"balance.window.session": "Current window",
+			"balance.window.weekly": "Weekly",
+			"balance.window.monthly": "Monthly",
+			"balance.window.billing": "Billing period",
+			"balance.window.hours": "{n}-hour window",
+			"balance.window.days": "{n}-day window",
+			"balance.window.minutes": "{n}-minute window",
+			"balance.window.reset": "resets {at}",
+			"balance.window.used": "{pct}% used",
+			"balance.window.unlimited": "Unlimited",
 			"balance.noRoute": "No direct DeepSeek route — relays have no balance API.",
 			"balance.unavailable": "This deployment exposes no provider directory.",
 			"footer.updated": "Read from your session logs {ago}",
@@ -1627,6 +1783,7 @@ window.__ModuleLoader__.load({
 		exports.ActivityStrip = ActivityStrip;
 		exports.ModelTable = ModelTable;
 		exports.BalanceCard = BalanceCard;
+		exports.QuotaWindows = QuotaWindows;
 		exports.AccountPicker = AccountPicker;
 		exports.Footer = Footer;
 		exports.agoLabel = agoLabel;

--- a/src/quota.js
+++ b/src/quota.js
@@ -1,0 +1,173 @@
+/**
+ * Rolling quota windows, normalized into one shape.
+ *
+ * ## What a window is
+ *
+ * A subscription account holds no money. It holds several independent
+ * allowances — five hours, a week, a month — each of which fills up and empties
+ * on its own clock. Knowing "the 5-hour window is 4% used and resets at 04:17"
+ * is the whole reason someone opens the panel, and the money-shaped envelope in
+ * `balance.js` has nowhere to put it: pick one window for `total` and the other
+ * two vanish.
+ *
+ * ## Why the caller says which unit it is sending
+ *
+ * The upstreams disagree about what a percentage is. Some send `0.04`, some
+ * send `4`, some send neither and leave you to divide `used` by `limit`. A
+ * reader that guesses from the magnitude gets it right almost always and wrong
+ * exactly where it matters: `0.04` is a plausible 0.04% and `4` is a plausible
+ * 4-in-100 ratio, so a nearly-empty window and a nearly-full one are the two
+ * cases the guess cannot separate.
+ *
+ * So there is no guess. `usedPercent` means 0..100, `usedRatio` means 0..1,
+ * `remainingPercent` is the complement, and `used`/`limit` are counts. Each
+ * scheme knows which one its vendor sends, and says so.
+ *
+ * ## Why relative times are resolved here
+ *
+ * "Resets in 3600 seconds" is only true at the instant it was read. Carried
+ * into a cache, a refresh interval, or a re-render, it silently becomes a lie.
+ * `now` is injected so this stays testable, and the stored value is always an
+ * absolute instant.
+ *
+ * @module dsh-tokenledger/quota
+ */
+
+/**
+ * The window shapes the panel can name.
+ *
+ * Deliberately short. An upstream's own enum ("ROLLING_5H", "TIME_LIMIT") must
+ * not reach the interface — a label nobody can read is worse than none — so a
+ * kind outside this list drops the window rather than rendering its raw name.
+ * The order is the display order: shortest clock first, because that is the one
+ * that stops you working.
+ */
+export const WINDOW_KINDS = ["session", "weekly", "monthly", "billing"];
+
+/** Parse a number a JSON API may have sent as a string. */
+function toNumber(value) {
+	if (typeof value === "number" && Number.isFinite(value)) return value;
+	if (typeof value === "string" && value.trim() !== "") {
+		const parsed = Number(value);
+		if (Number.isFinite(parsed)) return parsed;
+	}
+	return undefined;
+}
+
+/** 0..100, one decimal. Percentages are read, not computed against. */
+function clampPercent(value) {
+	if (value === undefined) return undefined;
+	return Math.round(Math.min(100, Math.max(0, value)) * 10) / 10;
+}
+
+/**
+ * How full the window is, from whichever of the four forms the caller sent.
+ *
+ * Order matters only in that each form is checked for presence, never for
+ * plausibility: a vendor sending `usedPercent: 0` means zero, and falling
+ * through to `used`/`limit` because zero is falsy is how a fresh window ends up
+ * rendered as unknown.
+ */
+function usedPercentOf(input) {
+	const direct = toNumber(input.usedPercent);
+	if (direct !== undefined) return clampPercent(direct);
+
+	const ratio = toNumber(input.usedRatio);
+	if (ratio !== undefined) return clampPercent(ratio * 100);
+
+	const remaining = toNumber(input.remainingPercent);
+	if (remaining !== undefined) return clampPercent(100 - remaining);
+
+	const used = toNumber(input.used);
+	const limit = toNumber(input.limit);
+	// A limit of zero is not a full window, it is an unreported one. Dividing by
+	// it yields Infinity, which clamps to 100 and tells the user they are out.
+	if (used !== undefined && limit !== undefined && limit > 0) return clampPercent((used / limit) * 100);
+
+	return undefined;
+}
+
+/**
+ * When the window next empties, as an absolute instant.
+ *
+ * Accepts an instant (`resetsAt`) or a duration from now (`resetInSeconds` /
+ * `resetInMs`). Epoch numbers are disambiguated by magnitude, which is safe
+ * here in a way the percentage guess was not: the ambiguous range is instants
+ * before 1970 or after the year 5138.
+ */
+function resetsAtOf(input, now) {
+	const seconds = toNumber(input.resetInSeconds);
+	if (seconds !== undefined && seconds >= 0) return new Date(now + seconds * 1000).toISOString();
+
+	const ms = toNumber(input.resetInMs);
+	if (ms !== undefined && ms >= 0) return new Date(now + ms).toISOString();
+
+	const at = input.resetsAt;
+	if (at === undefined || at === null || at === "") return undefined;
+
+	const epoch = toNumber(at);
+	const date = epoch === undefined ? new Date(String(at)) : new Date(epoch < 1e11 ? epoch * 1000 : epoch);
+	return Number.isNaN(date.getTime()) ? undefined : date.toISOString();
+}
+
+/**
+ * The window's own length in minutes, when the upstream reports it.
+ *
+ * Separate from `kind` because the interface has to be able to say "5-hour
+ * window" without inventing it. Plans differ — three hours here, five there —
+ * and a `session` label hard-coded to five hours is a number the panel made up.
+ * Absent, the panel falls back to naming the kind.
+ */
+function minutesOf(input) {
+	const minutes = toNumber(input.minutes);
+	return minutes !== undefined && minutes > 0 ? Math.round(minutes) : undefined;
+}
+
+/**
+ * One window, or `undefined` when the input cannot make one.
+ *
+ * @param input - `{ kind, usedPercent | usedRatio | remainingPercent | (used +
+ *   limit), unlimited?, resetsAt | resetInSeconds | resetInMs, minutes? }`.
+ * @param options - `{ now }`, milliseconds, injected so tests do not race.
+ */
+export function quotaWindow(input, options = {}) {
+	if (input === null || typeof input !== "object") return undefined;
+	if (!WINDOW_KINDS.includes(input.kind)) return undefined;
+
+	const now = options.now ?? Date.now();
+	const resetsAt = resetsAtOf(input, now);
+	const minutes = minutesOf(input);
+	const shared = { kind: input.kind, ...(minutes === undefined ? {} : { minutes }), ...(resetsAt === undefined ? {} : { resetsAt }) };
+
+	// An unlimited window has no fraction to show and is not the same fact as an
+	// empty one. It keeps its row — "unlimited" is worth saying — but carries no
+	// percentage, so nothing downstream can render it as a bar at 0%.
+	if (input.unlimited === true) return { ...shared, unlimited: true };
+
+	const usedPercent = usedPercentOf(input);
+	return usedPercent === undefined ? undefined : { ...shared, usedPercent };
+}
+
+/**
+ * A scheme's windows, cleaned and ordered.
+ *
+ * Unusable entries are dropped rather than rendered as blanks, one kind appears
+ * at most once (the first wins, so a reader can list its best source first),
+ * and the order is `WINDOW_KINDS` regardless of the order they arrived in —
+ * two accounts of the same plan must not lay their rows out differently.
+ */
+export function normalizeWindows(list, options = {}) {
+	if (!Array.isArray(list)) return undefined;
+
+	const byKind = new Map();
+	for (const entry of list) {
+		const window = quotaWindow(entry, options);
+		if (window !== undefined && !byKind.has(window.kind)) byKind.set(window.kind, window);
+	}
+
+	// Absent rather than empty: `windows: []` would make a card claim to be a
+	// subscription account with nothing in it, which is the same mistake as
+	// reporting an unread balance as zero.
+	if (byKind.size === 0) return undefined;
+	return WINDOW_KINDS.filter((kind) => byKind.has(kind)).map((kind) => byKind.get(kind));
+}

--- a/test/balance.test.js
+++ b/test/balance.test.js
@@ -553,6 +553,59 @@ test("zai reads available against total", async () => {
 	assert.equal(result.currency, "CNY");
 });
 
+// --- quota windows ------------------------------------------------------------
+
+test("a scheme describes what its vendor sent; readBalance does the arithmetic", async () => {
+	// Normalising centrally is the point: a reader says "a ratio" or "seconds
+	// from now" and never has to get the same conversion right a fifth time.
+	const now = Date.UTC(2026, 7, 17, 12, 0, 0);
+	const spec = {
+		label: "Stub",
+		read: async () => ({
+			plan: "Go",
+			windows: [
+				{ kind: "weekly", usedRatio: 0.82 },
+				{ kind: "session", minutes: 300, usedPercent: 4, resetInSeconds: 3600 }
+			]
+		})
+	};
+	SCHEMES.__stub = spec;
+	try {
+		const result = await readBalance({ scheme: "__stub", origin: "https://x.example", apiKey: "k", now, fetch: okJson({}) });
+		assert.deepEqual(result.windows, [
+			{ kind: "session", minutes: 300, resetsAt: "2026-08-17T13:00:00.000Z", usedPercent: 4 },
+			{ kind: "weekly", usedPercent: 82 }
+		]);
+		assert.equal(result.plan, "Go", "the rest of the reader's answer is untouched");
+	} finally {
+		delete SCHEMES.__stub;
+	}
+});
+
+test("a reader that emits nothing usable leaves no windows key at all", async () => {
+	// Not `windows: []`. An empty list would have the card claim to be a
+	// subscription account with nothing in it, which is the same lie as
+	// reporting an unread balance as zero.
+	SCHEMES.__stub = { label: "Stub", read: async () => ({ total: 5, windows: [{ kind: "ROLLING_5H", usedPercent: 3 }] }) };
+	try {
+		const result = await readBalance({ scheme: "__stub", origin: "https://x.example", apiKey: "k", fetch: okJson({}) });
+		assert.equal("windows" in result, false);
+		assert.equal(result.total, 5);
+	} finally {
+		delete SCHEMES.__stub;
+	}
+});
+
+test("a money scheme still returns no windows key", async () => {
+	const result = await readBalance({
+		scheme: "deepseek",
+		origin: "https://api.deepseek.com",
+		apiKey: "k",
+		fetch: okJson({ is_available: true, balance_infos: [{ currency: "CNY", total_balance: "3.00" }] })
+	});
+	assert.equal("windows" in result, false);
+});
+
 // --- vendors that refuse with a 200 ------------------------------------------
 //
 // Probed live with an invalid Bearer and a control path that does not exist:

--- a/test/client.test.js
+++ b/test/client.test.js
@@ -631,6 +631,144 @@ test("a real balance renders its amount and currency", async () => {
 	assert.ok(text.includes("balance.granted:¥5.00"), "granted credit expires and top-ups do not");
 });
 
+// --- quota windows -------------------------------------------------------------
+
+/** Three windows in the shape `readBalance` normalizes them into. */
+const WINDOWS = [
+	{ kind: "session", minutes: 300, usedPercent: 4, resetsAt: "2026-08-16T04:17:00.000Z" },
+	{ kind: "weekly", usedPercent: 82, resetsAt: "2026-08-17T08:00:00.000Z" },
+	{ kind: "monthly", usedPercent: 100 }
+];
+
+const subscription = (windows) => ({
+	status: "ready",
+	data: {
+		ok: true,
+		displayName: "opencode.ai",
+		scheme: "deepseek",
+		supported: true,
+		fetched: true,
+		isAvailable: true,
+		plan: "Go",
+		windows
+	}
+});
+
+test("a card with no windows renders exactly what it did before they existed", async () => {
+	// The card became a column to make room for them. With none, it holds a
+	// single child, the gap never applies, and nothing moves.
+	const { exports, render } = await loadBundle();
+	const tree = render(exports.BalanceCard, {
+		state: { status: "ready", data: { ok: true, displayName: "DeepSeek", scheme: "deepseek", supported: true, fetched: true, isAvailable: true, currency: "CNY", total: 36.44 } },
+		translate: T
+	});
+	assert.equal(findAll(tree, "tkl_wins").length, 0);
+	assert.equal(findAll(tree, "tkl_balanceTop").length, 1);
+	assert.ok(textOf(tree).includes("¥36.44"));
+});
+
+test("each window is one row naming itself, its reset and how full it is", async () => {
+	const { exports, render } = await loadBundle();
+	const tree = render(exports.BalanceCard, { state: subscription(WINDOWS), translate: T });
+	assert.equal(findAll(tree, "tkl_win").length, 3);
+
+	const text = textOf(tree);
+	assert.ok(text.includes("balance.window.hours:5"), "a five-hour window says five hours");
+	assert.ok(text.includes("balance.window.weekly"));
+	assert.ok(text.includes("balance.window.monthly"));
+	assert.ok(text.includes("balance.window.used:4"));
+	assert.ok(text.includes("balance.window.used:82"));
+	assert.ok(text.includes("balance.window.reset:"), "a reset instant is shown when there is one");
+});
+
+test("money and windows both show, because an account can hold both", async () => {
+	// A plan with a top-up wallet behind it is ordinary. A `mode` flag would
+	// force a choice reality does not make.
+	const { exports, render } = await loadBundle();
+	const state = subscription(WINDOWS);
+	state.data.currency = "USD";
+	state.data.total = 12.5;
+	const text = textOf(render(exports.BalanceCard, { state, translate: T }));
+	assert.ok(text.includes("$12.50"));
+	assert.ok(text.includes("balance.window.used:4"));
+});
+
+test("the bar's width is the percentage, and its colour only repeats it", async () => {
+	// Colour is a second channel. The number sits beside every bar, so the
+	// three bands are readable without distinguishing green from amber.
+	const { exports, render } = await loadBundle();
+	const fills = findAll(render(exports.BalanceCard, { state: subscription(WINDOWS), translate: T }), "tkl_winFill");
+	assert.deepEqual(fills.map((f) => f.props.style.width), ["4%", "82%", "100%"]);
+	assert.equal(fills[0].props.className.includes("tkl_winWarn"), false, "4% is not a warning");
+	assert.ok(fills[1].props.className.includes("tkl_winWarn"), "82% is close enough to matter");
+	assert.ok(fills[2].props.className.includes("tkl_winFull"), "100% is spent, not merely close");
+});
+
+test("every bar is a labelled progressbar", async () => {
+	const { exports, render } = await loadBundle();
+	for (const bar of findAll(render(exports.BalanceCard, { state: subscription(WINDOWS), translate: T }), "tkl_winBar")) {
+		assert.equal(bar.props.role, "progressbar");
+		assert.equal(bar.props["aria-valuemin"], 0);
+		assert.equal(bar.props["aria-valuemax"], 100);
+		assert.equal(typeof bar.props["aria-valuenow"], "number");
+		assert.ok(String(bar.props["aria-label"]).startsWith("balance.window."), "a bar with no name is a bar nobody can read");
+	}
+});
+
+test("an unlimited window says so and draws no bar", async () => {
+	// A bar at 0% would read as "none used of a finite allowance", which is the
+	// opposite of what unlimited means.
+	const { exports, render } = await loadBundle();
+	const tree = render(exports.BalanceCard, { state: subscription([{ kind: "weekly", unlimited: true }]), translate: T });
+	assert.ok(textOf(tree).includes("balance.window.unlimited"));
+	assert.equal(findAll(tree, "tkl_winBar").length, 0);
+	assert.equal(findAll(tree, "tkl_win").length, 1, "it still gets a row — unlimited is worth saying");
+});
+
+test("a window with no reset shows its bar and stays quiet about the clock", async () => {
+	const { exports, render } = await loadBundle();
+	const tree = render(exports.BalanceCard, { state: subscription([{ kind: "monthly", usedPercent: 30 }]), translate: T });
+	assert.equal(findAll(tree, "tkl_winReset").length, 0);
+	assert.equal(findAll(tree, "tkl_winBar").length, 1);
+});
+
+test("a session window with no reported length falls back to naming the kind", async () => {
+	// The length is only shown when the upstream sent one. Hard-coding five
+	// hours would be a number the panel made up, and plans differ.
+	const { exports, render } = await loadBundle();
+	const text = textOf(render(exports.QuotaWindows, { windows: [{ kind: "session", usedPercent: 9 }], translate: T }));
+	assert.ok(text.includes("balance.window.session"));
+	assert.equal(text.includes("balance.window.hours"), false);
+});
+
+test("a window length is spoken in whichever unit divides it evenly", async () => {
+	const { exports, render } = await loadBundle();
+	const label = (minutes) =>
+		textOf(render(exports.QuotaWindows, { windows: [{ kind: "session", usedPercent: 1, minutes }], translate: T }));
+	assert.ok(label(300).includes("balance.window.hours:5"));
+	assert.ok(label(1440).includes("balance.window.days:1"));
+	assert.ok(label(90).includes("balance.window.minutes:90"));
+});
+
+test("nothing renders for an absent or empty window list", async () => {
+	const { exports, render } = await loadBundle();
+	for (const windows of [undefined, [], null, "weekly"]) {
+		assert.equal(render(exports.QuotaWindows, { windows, translate: T }), null, JSON.stringify(windows));
+	}
+});
+
+test("both dictionaries carry every window key", async () => {
+	// A missing key renders the key itself, which on a card of numbers looks
+	// like a bug in the data rather than a gap in the translations.
+	const { exports } = await loadBundle();
+	const keys = Object.keys(exports.zh).filter((key) => key.startsWith("balance.window."));
+	assert.ok(keys.length >= 10, `expected every kind, unit and label: ${keys.length}`);
+	for (const key of keys) {
+		assert.equal(typeof exports.en[key], "string", `${key} is missing from en`);
+		assert.notEqual(exports.en[key], "", key);
+	}
+});
+
 test("unattributed rows are surfaced on the page, not only in a command", async () => {
 	const { exports, render } = await loadBundle();
 	const clean = textOf(render(exports.Footer, { data: payload(), translate: T }));

--- a/test/quota.test.js
+++ b/test/quota.test.js
@@ -1,0 +1,188 @@
+/**
+ * Rolling quota windows.
+ *
+ * Every test here is about one of two mistakes. The first is guessing what unit
+ * a number is in, which works until it meets the one account where the guess is
+ * wrong. The second is turning "cannot tell" into a confident zero, which is
+ * how a panel ends up telling someone their allowance is untouched when it has
+ * actually run out.
+ */
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { WINDOW_KINDS, normalizeWindows, quotaWindow } from "../src/quota.js";
+
+/** A fixed clock, so relative resets land somewhere assertable. */
+const NOW = Date.UTC(2026, 7, 17, 12, 0, 0);
+const at = (ms) => new Date(NOW + ms).toISOString();
+
+// --- how full ----------------------------------------------------------------
+
+test("each way of saying how full a window is arrives at the same number", () => {
+	const forms = [
+		{ usedPercent: 40 },
+		{ usedRatio: 0.4 },
+		{ remainingPercent: 60 },
+		{ used: 400, limit: 1000 }
+	];
+	for (const form of forms) {
+		const window = quotaWindow({ kind: "session", ...form }, { now: NOW });
+		assert.equal(window.usedPercent, 40, JSON.stringify(form));
+	}
+});
+
+test("the unit is declared, never inferred from the magnitude", () => {
+	// This is the whole reason the four forms are separate fields. A reader that
+	// guesses gets `4` and `0.04` exactly backwards half the time, and those are
+	// a nearly-full window and a nearly-empty one — the two cases where being
+	// wrong actually costs someone something.
+	assert.equal(quotaWindow({ kind: "session", usedPercent: 4 }, { now: NOW }).usedPercent, 4);
+	assert.equal(quotaWindow({ kind: "session", usedRatio: 4 }, { now: NOW }).usedPercent, 100, "clamped, not reinterpreted");
+	assert.equal(quotaWindow({ kind: "session", usedRatio: 0.04 }, { now: NOW }).usedPercent, 4);
+	assert.equal(quotaWindow({ kind: "session", usedPercent: 0.04 }, { now: NOW }).usedPercent, 0, "0.04% rounds to 0.0");
+});
+
+test("a window at zero is reported as zero, not as unknown", () => {
+	// `usedPercent: 0` is falsy. Falling through to the next form because of
+	// that renders a fresh window as if nothing could be read from it.
+	const window = quotaWindow({ kind: "weekly", usedPercent: 0, used: 999, limit: 1000 }, { now: NOW });
+	assert.equal(window.usedPercent, 0);
+});
+
+test("a limit of zero is an unreported window, not a full one", () => {
+	// Dividing by it gives Infinity, which clamps to 100 and tells the user they
+	// are out of allowance on a plan whose size the vendor simply did not send.
+	assert.equal(quotaWindow({ kind: "session", used: 5, limit: 0 }, { now: NOW }), undefined);
+	assert.equal(quotaWindow({ kind: "session", used: 5 }, { now: NOW }), undefined, "a count with no limit is not a fraction");
+});
+
+test("percentages are clamped and kept to one decimal", () => {
+	assert.equal(quotaWindow({ kind: "session", usedPercent: 143 }, { now: NOW }).usedPercent, 100);
+	assert.equal(quotaWindow({ kind: "session", usedPercent: -8 }, { now: NOW }).usedPercent, 0);
+	assert.equal(quotaWindow({ kind: "session", used: 1, limit: 3 }, { now: NOW }).usedPercent, 33.3);
+});
+
+test("numbers sent as strings are read", () => {
+	assert.equal(quotaWindow({ kind: "weekly", usedPercent: "62.5" }, { now: NOW }).usedPercent, 62.5);
+	assert.equal(quotaWindow({ kind: "weekly", usedPercent: "" }, { now: NOW }), undefined);
+	assert.equal(quotaWindow({ kind: "weekly", usedPercent: "n/a" }, { now: NOW }), undefined);
+});
+
+test("an unlimited window keeps its row and carries no percentage", () => {
+	// It is not the same fact as an empty one, and a bar drawn at 0% says the
+	// opposite of what it means: none used OF A FINITE ALLOWANCE.
+	const window = quotaWindow({ kind: "weekly", unlimited: true }, { now: NOW });
+	assert.deepEqual(window, { kind: "weekly", unlimited: true });
+	assert.equal("usedPercent" in window, false);
+});
+
+test("unlimited outranks a percentage sent alongside it", () => {
+	const window = quotaWindow({ kind: "weekly", unlimited: true, usedPercent: 0 }, { now: NOW });
+	assert.equal(window.unlimited, true);
+	assert.equal(window.usedPercent, undefined);
+});
+
+// --- when it resets -----------------------------------------------------------
+
+test("a duration from now is resolved to an instant at read time", () => {
+	// "Resets in 3600 seconds" is true only at the moment it was read. Stored as
+	// a duration it survives a cache, a refresh and a re-render, and lies during
+	// all three.
+	assert.equal(quotaWindow({ kind: "session", usedPercent: 1, resetInSeconds: 3600 }, { now: NOW }).resetsAt, at(3600_000));
+	assert.equal(quotaWindow({ kind: "session", usedPercent: 1, resetInMs: 90_000 }, { now: NOW }).resetsAt, at(90_000));
+});
+
+test("an instant is accepted as ISO, as epoch seconds, and as epoch milliseconds", () => {
+	const iso = at(0);
+	for (const form of [iso, Math.floor(NOW / 1000), NOW, new Date(NOW).toUTCString()]) {
+		assert.equal(quotaWindow({ kind: "session", usedPercent: 1, resetsAt: form }, { now: NOW }).resetsAt, iso, String(form));
+	}
+});
+
+test("a reset nobody sent stays absent rather than being invented", () => {
+	const window = quotaWindow({ kind: "monthly", usedPercent: 12 }, { now: NOW });
+	assert.equal("resetsAt" in window, false);
+	for (const bad of ["", null, "next tuesday", Number.NaN]) {
+		const w = quotaWindow({ kind: "monthly", usedPercent: 12, resetsAt: bad }, { now: NOW });
+		assert.equal("resetsAt" in w, false, JSON.stringify(bad));
+	}
+});
+
+test("a negative duration is not a reset in the past", () => {
+	// It means the field was not really populated. Rendering it produces a
+	// window that claims to have reset before it was read.
+	const window = quotaWindow({ kind: "session", usedPercent: 1, resetInSeconds: -60 }, { now: NOW });
+	assert.equal("resetsAt" in window, false);
+});
+
+// --- what it is called ---------------------------------------------------------
+
+test("a kind outside the list drops the window rather than showing a raw enum", () => {
+	// The upstreams call these things TOKENS_LIMIT, ROLLING_5H, TIME_LIMIT. A
+	// label nobody can read is worse than no row at all.
+	for (const kind of ["TOKENS_LIMIT", "rolling", undefined, "", 5]) {
+		assert.equal(quotaWindow({ kind, usedPercent: 10 }, { now: NOW }), undefined, String(kind));
+	}
+	for (const kind of WINDOW_KINDS) {
+		assert.equal(quotaWindow({ kind, usedPercent: 10 }, { now: NOW }).kind, kind);
+	}
+});
+
+test("a window length rides along when the upstream reports one", () => {
+	assert.equal(quotaWindow({ kind: "session", usedPercent: 4, minutes: 300 }, { now: NOW }).minutes, 300);
+	assert.equal("minutes" in quotaWindow({ kind: "session", usedPercent: 4 }, { now: NOW }), false);
+	assert.equal("minutes" in quotaWindow({ kind: "session", usedPercent: 4, minutes: 0 }, { now: NOW }), false);
+	assert.equal("minutes" in quotaWindow({ kind: "session", usedPercent: 4, minutes: -5 }, { now: NOW }), false);
+});
+
+test("a non-object is not a window", () => {
+	for (const junk of [null, undefined, "session", 5, []]) {
+		assert.equal(quotaWindow(junk, { now: NOW }), undefined, JSON.stringify(junk));
+	}
+});
+
+// --- the list ------------------------------------------------------------------
+
+test("windows are ordered by clock length, whatever order they arrived in", () => {
+	// Two accounts on the same plan must not lay their rows out differently
+	// because one vendor happened to serialize them backwards.
+	const windows = normalizeWindows(
+		[
+			{ kind: "billing", usedPercent: 1 },
+			{ kind: "monthly", usedPercent: 2 },
+			{ kind: "weekly", usedPercent: 3 },
+			{ kind: "session", usedPercent: 4 }
+		],
+		{ now: NOW }
+	);
+	assert.deepEqual(windows.map((w) => w.kind), ["session", "weekly", "monthly", "billing"]);
+});
+
+test("one kind appears once, and the first source wins", () => {
+	// A reader listing its best source first should get it, so that a fallback
+	// field cannot overwrite the authoritative one.
+	const windows = normalizeWindows(
+		[{ kind: "weekly", usedPercent: 10 }, { kind: "weekly", usedPercent: 90 }],
+		{ now: NOW }
+	);
+	assert.equal(windows.length, 1);
+	assert.equal(windows[0].usedPercent, 10);
+});
+
+test("unusable entries are dropped without taking the usable ones with them", () => {
+	const windows = normalizeWindows(
+		[null, { kind: "nonsense", usedPercent: 1 }, { kind: "weekly" }, { kind: "session", usedPercent: 7 }],
+		{ now: NOW }
+	);
+	assert.deepEqual(windows, [{ kind: "session", usedPercent: 7 }]);
+});
+
+test("no windows means absent, not an empty list", () => {
+	// `windows: []` would have a card claim to be a subscription account with
+	// nothing in it — the same lie as reporting an unread balance as zero.
+	assert.equal(normalizeWindows([], { now: NOW }), undefined);
+	assert.equal(normalizeWindows([{ kind: "weekly" }], { now: NOW }), undefined);
+	assert.equal(normalizeWindows(undefined, { now: NOW }), undefined);
+	assert.equal(normalizeWindows("weekly", { now: NOW }), undefined);
+});


### PR DESCRIPTION
Closes #11。只做模型、渲染和文案，用夹具驱动，**不接任何真实供应商**——真实供应商在 #12。

## 新增 `src/quota.js`

一个模块，两个导出：`quotaWindow(input, {now})` 归一化一条，`normalizeWindows(list, {now})` 归一化一组。`readBalance` 在 scheme 的 `read()` 返回之后跑一遍，所以后面每个 scheme 只需要**描述上游给了什么**，不用第五次重写同一段换算。

## 三个设计决定，每个都有它防的东西

### 1. 单位由调用方声明，不猜

`usedPercent` 是 0..100，`usedRatio` 是 0..1，`remainingPercent` 是补数，`used`/`limit` 是计数。四个字段名，各自说清楚。

按数值大小猜单位（"小于 1 就当比例"）几乎总是对的，而它出错的地方恰好是最要命的：**`0.04` 是个说得通的 0.04%，`4` 是个说得通的 4/100**，一个快满的窗口和一个几乎没用的窗口，正好是这个猜法分不开的两种情况。有一个测试专门盯着这一对。

### 2. 金额和窗口并存，不设 `mode`

用 `mode: "balance" | "subscription"` 会强迫二选一，但"套餐 + 钱包"是很普通的账户形态。所以**由字段在不在决定渲染什么**，和本模块"缺席是一种事实"的既有约定一致。

同理，一条窗口都没有时 `windows` 这个键**不存在**，而不是 `[]`——空数组等于宣称"这是个订阅账户，里面什么都没有"，跟把读不到的余额显示成 0 是同一个错。

### 3. 相对时间当场折算成绝对时刻

"还有 3600 秒重置"只在读到它的那一瞬间是真的。存进缓存、过一次刷新、重渲染一次，它就开始撒谎。`now` 可注入，测试不用跟时钟赛跑。

## 界面

卡片改成纵向：原来那一行整体挪进 `.tkl_balanceTop`，窗口排在它下面。**没有窗口时容器只有一个子元素，`gap` 不生效，渲染与改动前完全一致**（有测试守）。

每条窗口一行：名称 + 重置时刻 + 已用百分比 + 一根进度条。

- **窗口名称来自数据。** `minutes` 只对 `session` 生效——它是唯一一个名字本身没说明时长的种类，有的计划滚动窗口是 5 小时，有的是 3 小时，把 `session` 写死成"5 小时"就是面板自己编了个数字。`weekly` / `monthly` 名字里已经有周期了。
- **颜色只是复述。** 三档（<75 / 75–99 / ≥100）用 DSH 自己的 state 令牌，跟随主题和皮肤；百分比数字就在进度条旁边，所以状态不依赖分辨绿色和琥珀色。
- **进度条是 `role="progressbar"`**，带 `aria-valuenow/min/max` 和一个能读的 `aria-label`。
- **不限量的窗口保留一行但不画条。** 一根停在 0% 的条读起来是"一份有限额度一点没用"，和"不限量"的意思正好相反。

上游自己的枚举名（`TOKENS_LIMIT`、`ROLLING_5H`）不会漏到界面上——不认识的 `kind` 直接丢掉这一行，一个没人看得懂的标签比没有更糟。

## 测试

+33（`test/quota.test.js` 19、`test/client.test.js` 11、`test/balance.test.js` 3），共 **299 个全绿**。

值得单独提的几条：

- `usedPercent: 0` 必须读成 0，不能因为 0 是 falsy 就往下一种形式落——那会让一个刚重置的窗口显示成"读不出来"
- `limit: 0` 是"没上报"，不是"满了"——除下去是 Infinity，钳完变 100%，等于告诉用户额度用光了
- `resetInSeconds: -60` 不产生一个"过去才重置过"的时刻
- 排序固定按窗口时长，不随上游序列化顺序变——同一个套餐的两个账户不该排得不一样

## 顺带

`package.json` 加了 `./quota` 子路径导出。
