### PR TITLE
feat: 接入四家订阅制供应商的配额读取

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ to the relay site that served each request. Zero configuration.
 | 🎯 | **中转站归属** | 按 provider 的 `baseURL` 归一化 origin 分组——同一站的多把 key 合成一行，站名就是域名，不是你自己起的路由别名 |
 | 🔍 | **零配置发现** | 从宿主的 provider 配置里读出中转站，不用你再填一遍。只读 `baseURL`，绝不碰旁边的凭据 |
 | 💳 | **余额** | DeepSeek 官方、New API、Sub2API，每个账户一把普通 key 即可；不限额度的 key 报"已用"而不是假余额 |
+| ⏳ | **订阅配额** | 卖套餐不卖余额的家数越来越多——5 小时 / 每周 / 每月各自滚动、各自重置，每个窗口一条进度条和一个重置时刻 |
 | 📊 | **用量分析** | 今日/本月/累计三窗口、按站点/模型下钻、缓存命中率、一年活跃度热力图（悬停看当天模型构成） |
 | 🧮 | **费用估算** | 生效日期分段的费率表、分桶计价、峰谷时段；未定价的模型显示破折号而不是 0 |
 | 🗂 | **导出与诊断** | CSV / JSON 导出，索引健康度，归因不上的行数单独列出 |
@@ -71,8 +72,18 @@ dsh plugin --profile web remove dsh-tokenledger
 | Moonshot / Kimi | 余额 | provider 的 `apiKeyEnv` | `/v1/users/me/balance` |
 | 智谱 GLM / Z.ai | 余额 | provider 的 `apiKeyEnv` | `/api/paas/v4/balance` |
 | OpenRouter | 余额 | **Management Key** | `/api/v1/credits` |
+| OpenCode Go | 订阅 | provider 的 `apiKeyEnv`，或本机 `auth.json` | `/zen/go/v1/usage` |
+| Kimi For Coding | 订阅 | provider 的 `apiKeyEnv` | `/coding/v1/usages` |
+| MiniMax Coding Plan | 订阅 | provider 的 `apiKeyEnv` | `/v1/token_plan/remains` |
+| 智谱 GLM / Z.ai Coding Plan | 订阅 + 余额 | provider 的 `apiKeyEnv` | `/api/monitor/usage/quota/limit` |
 
 除 OpenRouter 外都只需要一把**普通 API key**——就是你已经配给那条路由、用来发请求的那把。OpenRouter 的额度接口只认 Management Key，用推理 key 会 401，面板会直接说明要哪一把，而不是丢一个 401 让你去查一把本来没问题的 key。
+
+**订阅**这一档没有余额可读，读到的是若干个滚动窗口：一条进度条、一个百分比、一个重置时刻。金额和窗口**可以同时存在**——Z.ai 就是既有钱包又有 Coding Plan，两样都读，任一边读不到也不影响另一边。
+
+OpenCode Go 那条的"本机 `auth.json`"是个便利：路由上没配 `apiKeyEnv` 时，会去读 OpenCode 客户端自己存 key 的那个文件（`~/.local/share/opencode/auth.json`），key 只发回它本来的来处。文件不存在、读不动、格式变了，一律当作"没有凭据"，安静退回，不会因此报错。
+
+这几家订阅接口都没有公开 schema。字段位置不对时，卡片会**说出它去哪儿找过**，而不是留一张空卡——那句话可以直接反馈给我们。
 
 中转站跑的是哪套程序由路由指纹自动判定，第一次查余额时探测一次并记住。厂商自己的域名不需要探测——origin 直接决定用哪套读法，而且同一厂商的多条路由会合并成一个账户（一个钱包），这跟中转站正好相反。
 

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "./relay-sites": "./src/relay-sites.js",
     "./report": "./src/report.js",
     "./store": "./src/store.js",
+    "./subscriptions": "./src/subscriptions.js",
     "./usage": "./src/usage.js"
   },
   "files": [

--- a/src/balance.js
+++ b/src/balance.js
@@ -45,6 +45,7 @@
 import { detectRelaySoftware } from "./adapters/detect.js";
 import { normalizeWindows } from "./quota.js";
 import { normalizeOrigin } from "./relay-sites.js";
+import { KIMI, MINIMAX, OPENCODE_GO, readZaiCodingPlan } from "./subscriptions.js";
 
 /** The vendor's own endpoint, and the only origin the `deepseek` scheme calls. */
 export const DEEPSEEK_ORIGIN = "https://api.deepseek.com";
@@ -84,7 +85,14 @@ const VENDORS = new Map([
 	["api.moonshot.cn", { scheme: "moonshot", displayName: "Moonshot", currency: "CNY" }],
 	["api.moonshot.ai", { scheme: "moonshot", displayName: "Moonshot" }],
 	["api.z.ai", { scheme: "zai", displayName: "Z.ai" }],
-	["open.bigmodel.cn", { scheme: "zai", displayName: "智谱 GLM", currency: "CNY" }]
+	["open.bigmodel.cn", { scheme: "zai", displayName: "智谱 GLM", currency: "CNY" }],
+	// Plan vendors. No wallet to read — see `subscriptions.js`.
+	["opencode.ai", { scheme: "opencode-go", displayName: "OpenCode Go" }],
+	["api.kimi.com", { scheme: "kimi", displayName: "Kimi For Coding" }],
+	["api.minimax.io", { scheme: "minimax", displayName: "MiniMax" }],
+	["www.minimax.io", { scheme: "minimax", displayName: "MiniMax" }],
+	["api.minimaxi.com", { scheme: "minimax", displayName: "MiniMax", currency: "CNY" }],
+	["www.minimaxi.com", { scheme: "minimax", displayName: "MiniMax", currency: "CNY" }]
 ]);
 
 /**
@@ -214,19 +222,43 @@ export const SCHEMES = {
 			const refused = body?.success === false || (code !== undefined && code !== 0 && code !== 200);
 			return refused ? { status: code, message: typeof body?.msg === "string" ? body.msg : undefined } : undefined;
 		},
+		// This vendor sells both a wallet and a Coding Plan, and an account can
+		// hold both at once, so both are read and either may fail alone. A plan
+		// user with an empty wallet must not see an empty card, and a wallet user
+		// with no plan must not see the balance disappear because a second route
+		// answered 404.
 		async read({ origin, get, vendor }) {
-			const body = await get(new URL("/api/paas/v4/balance", origin).href);
-			const data = body?.data;
+			const [wallet, plan] = await Promise.allSettled([
+				get(new URL("/api/paas/v4/balance", origin).href),
+				readZaiCodingPlan({ origin, get })
+			]);
+			if (wallet.status === "rejected" && plan.status === "rejected") throw wallet.reason;
+
+			const data = wallet.status === "fulfilled" ? wallet.value?.data : undefined;
 			const available = toNumber(data?.available_balance);
 			const total = toNumber(data?.total_balance) ?? available;
+			const coding = plan.status === "fulfilled" ? plan.value : undefined;
+			const windows = coding?.windows ?? [];
+
 			return {
-				isAvailable: total === undefined ? undefined : total > 0,
+				isAvailable:
+					total !== undefined
+						? total > 0
+						: windows.length === 0
+							? undefined
+							: windows.some((w) => w.unlimited === true || (w.usedPercent ?? 0) < 100),
 				currency: typeof data?.currency === "string" ? data.currency : vendor?.currency,
 				total: available ?? total,
-				granted: total
+				granted: total,
+				...(coding?.plan === undefined ? {} : { plan: coding.plan }),
+				windows
 			};
 		}
 	},
+
+	"opencode-go": OPENCODE_GO,
+	kimi: KIMI,
+	minimax: MINIMAX,
 
 	newapi: {
 		label: "New API",
@@ -312,9 +344,17 @@ export const SCHEMES = {
  *   no key look like a failed route.
  */
 export async function readBalance(options = {}) {
-	const { scheme, origin, apiKey, timeoutMs = 15_000 } = options;
+	const { scheme, origin, timeoutMs = 15_000 } = options;
 	const spec = SCHEMES[scheme];
 	if (spec === undefined) return { supported: false, reason: "unknown-software" };
+
+	// A scheme may know where its vendor's own client already keeps a key. Only
+	// consulted when the route carries none, and only ever able to say "no
+	// credential" on failure — see `localCredential` on the scheme.
+	let apiKey = options.apiKey;
+	if ((typeof apiKey !== "string" || apiKey === "") && spec.localCredential !== undefined) {
+		apiKey = await spec.localCredential(options).catch(() => undefined);
+	}
 	if (typeof apiKey !== "string" || apiKey === "") {
 		return { supported: true, fetched: false, reason: "no-credential" };
 	}
@@ -322,15 +362,29 @@ export async function readBalance(options = {}) {
 	const doFetch = options.fetch ?? globalThis.fetch;
 	const controller = new AbortController();
 	const timer = setTimeout(() => controller.abort(), timeoutMs);
-	const get = async (url, { anonymous = false } = {}) => {
+	/**
+	 * @param options - `{ anonymous }` sends no credential at all; `{ raw }`
+	 *   sends the key without the `Bearer` prefix, which some vendors' console
+	 *   routes want even though their inference API does not. Either way the key
+	 *   rides the Authorization header and never a query string.
+	 */
+	const get = async (url, { anonymous = false, raw = false } = {}) => {
 		const response = await doFetch(url, {
 			headers: anonymous
 				? { accept: "application/json" }
-				: { authorization: `Bearer ${apiKey}`, accept: "application/json" },
+				: { authorization: raw ? apiKey : `Bearer ${apiKey}`, accept: "application/json" },
 			signal: controller.signal
 		});
 		if (!response.ok) throw Object.assign(new Error(`http-${response.status}`), { status: response.status });
-		const body = await response.json();
+		let body;
+		try {
+			body = await response.json();
+		} catch {
+			// A host that answers HTML where JSON was asked for is not serving
+			// this route. Marked rather than thrown bare, so a reader that has a
+			// second host to try can tell that apart from a real refusal.
+			throw Object.assign(new Error("invalid-json"), { kind: "invalid-json" });
+		}
 		// Run before the reader sees it, so a refusal can never be mistaken for a
 		// response whose fields all happen to be missing.
 		const refusal = spec.envelope?.(body);
@@ -362,9 +416,11 @@ export async function readBalance(options = {}) {
 				? `upstream-${error.status ?? "error"}`
 				: error?.status !== undefined
 					? `http-${error.status}`
-					: error?.name === "AbortError"
-						? "timeout"
-						: "unreachable";
+					: error?.kind === "invalid-json"
+						? "invalid-response"
+						: error?.name === "AbortError"
+							? "timeout"
+							: "unreachable";
 		// A scheme whose endpoint wants a different credential from the one the
 		// route carries says so, rather than leaving the card on a bare 401 that
 		// reads as "your key is wrong".

--- a/src/client.js
+++ b/src/client.js
@@ -1240,6 +1240,15 @@ window.__ModuleLoader__.load({
 				notes.push(translate("balance.plan", { plan: balance.plan }));
 			}
 
+			// A request that succeeded and produced nothing readable is the one
+			// failure a blank card cannot express. These payloads have no
+			// published schema, so the reader says which field it went looking
+			// for and the user has something to forward instead of "it's empty".
+			const unparsed =
+				balance.windows === undefined && balance.total === undefined && typeof balance.reason === "string"
+					? translate("balance.unparsed", { reason: balance.reason })
+					: undefined;
+
 			return jsxs("div", {
 				className: S.balance,
 				children: [
@@ -1253,7 +1262,7 @@ window.__ModuleLoader__.load({
 							// answers nothing on a panel that also reports relays.
 							jsx("div", {
 								className: S.balanceWho,
-								children: [balance.displayName, SCHEME_LABELS[balance.scheme] ?? balance.scheme, balance.keyName]
+								children: [balance.displayName, SCHEME_LABELS[balance.scheme], balance.keyName]
 									.filter(Boolean)
 									.join(" · ")
 							}),
@@ -1282,12 +1291,19 @@ window.__ModuleLoader__.load({
 					}),
 					// Under the amount, not instead of it. An account can hold both
 					// a wallet and a plan, and the card has to be able to say so.
-					jsx(QuotaWindows, { windows: balance.windows, translate })
+					jsx(QuotaWindows, { windows: balance.windows, translate }),
+					unparsed === undefined ? null : jsx("p", { className: S.note, children: unparsed })
 				]
 			});
 		}
 
-		/** How each relay program is named on the card. */
+		/**
+		 * How each relay program is named on the card.
+		 *
+		 * Only where the name adds something the host does not already say. A
+		 * vendor whose display name is already "OpenCode Go" gains nothing from a
+		 * second "OpenCode Go" beside it.
+		 */
 		const SCHEME_LABELS = { deepseek: "API 余额", newapi: "New API", sub2api: "Sub2API" };
 
 		/** Index health. A stale or lossy index must say so on the page. */
@@ -1610,6 +1626,7 @@ window.__ModuleLoader__.load({
 			"balance.active": "账户可用",
 			"balance.inactive": "账户不可用",
 			"balance.granted": "其中赠送 {amount}",
+			"balance.unparsed": "接口答了，但认不出配额字段（{reason}）。可以把这句话反馈给我们。",
 			"balance.window.session": "当前窗口",
 			"balance.window.weekly": "每周窗口",
 			"balance.window.monthly": "每月窗口",
@@ -1698,6 +1715,7 @@ window.__ModuleLoader__.load({
 			"balance.active": "Account active",
 			"balance.inactive": "Account inactive",
 			"balance.granted": "{amount} granted",
+			"balance.unparsed": "The endpoint answered, but none of the quota fields were where they were expected ({reason}). Worth reporting.",
 			"balance.window.session": "Current window",
 			"balance.window.weekly": "Weekly",
 			"balance.window.monthly": "Monthly",

--- a/src/subscriptions.js
+++ b/src/subscriptions.js
@@ -1,0 +1,384 @@
+/**
+ * Vendors that sell a plan rather than a balance.
+ *
+ * ## What is verified here and what is not
+ *
+ * Two different things get called "supported", and conflating them is how a
+ * feature ships broken. What was checked directly, with an invalid key and a
+ * control path that does not exist:
+ *
+ * - the endpoint is served at that host, and answers JSON
+ * - which status code it uses to refuse, and whether that code means anything
+ *   (see `balance.js` on the vendors that refuse with a 200)
+ *
+ * What could **not** be checked without a paying account is the shape of a
+ * successful body. Every reader below is therefore written to fail into a
+ * stated reason rather than a blank card: if the fields are not where they were
+ * expected, the card says so in words a user can forward, and the rest of the
+ * panel is untouched. That diagnostic is the feature, not an apology for one —
+ * these payloads have no published schema and will drift.
+ *
+ * ## The rule about units
+ *
+ * A field whose name contains "percent" is read as 0..100. Not sometimes; the
+ * word means that. A vendor that puts a ratio in a field called `percent` is a
+ * bug worth surfacing loudly rather than compensating for silently, because the
+ * compensation is a guess and the two readings it has to choose between are
+ * "almost empty" and "almost full". `quota.js` refuses to guess for the same
+ * reason, and nothing here undoes that.
+ *
+ * @module dsh-tokenledger/subscriptions
+ */
+
+import { readFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+/** Parse a number a JSON API may have sent as a string. */
+function toNumber(value) {
+	if (typeof value === "number" && Number.isFinite(value)) return value;
+	if (typeof value === "string" && value.trim() !== "") {
+		const parsed = Number(value);
+		if (Number.isFinite(parsed)) return parsed;
+	}
+	return undefined;
+}
+
+/** The first key present on an object, whatever it is spelled. */
+function pick(source, ...keys) {
+	if (source === null || typeof source !== "object") return undefined;
+	for (const key of keys) {
+		if (source[key] !== undefined && source[key] !== null) return source[key];
+	}
+	return undefined;
+}
+
+/** A trimmed non-empty string, or undefined. Plan names arrive padded. */
+function label(value) {
+	const text = typeof value === "string" ? value.trim() : "";
+	return text === "" ? undefined : text;
+}
+
+/**
+ * When a window next empties, in whichever of the two forms it was sent.
+ *
+ * A duration is handed on as a duration: `quota.js` resolves it against a
+ * single injected `now`, so every window on a card agrees about what time it
+ * is, and no reader has to reach for the clock itself.
+ */
+function whenOf(source) {
+	const seconds = toNumber(pick(source, "resetInSec", "resetInSeconds", "resetSeconds"));
+	if (seconds !== undefined) return { resetInSeconds: seconds };
+	const at = pick(source, "resetsAt", "resetAt", "resetTime", "reset_time", "nextReset", "next_reset");
+	return at === undefined ? {} : { resetsAt: at };
+}
+
+/**
+ * A window built from a `{used, limit, remaining}` trio.
+ *
+ * Common enough across these vendors to be worth one implementation. `limit`
+ * with `remaining` is preferred over `limit` with `used`, because a vendor that
+ * reports both sometimes zeroes the counter it is not using.
+ */
+function fromCounts(source, kind, extra = {}) {
+	const limit = toNumber(pick(source, "limit", "total", "quota", "total_count", "totalCount"));
+	if (limit === undefined || limit <= 0) return undefined;
+	const remaining = toNumber(pick(source, "remaining", "remain", "left"));
+	if (remaining !== undefined) return { kind, used: limit - remaining, limit, ...extra };
+	const used = toNumber(pick(source, "used", "usage", "consumed", "usage_count", "usageCount"));
+	return used === undefined ? undefined : { kind, used, limit, ...extra };
+}
+
+// --- OpenCode Go ---------------------------------------------------------------
+
+/** Where the OpenCode client keeps the key it was issued. */
+const OPENCODE_AUTH_PATH = [".local", "share", "opencode", "auth.json"];
+
+/**
+ * One window off the Go usage payload.
+ *
+ * `percent` is 0..100 by the rule above. Counts are the fallback, not a
+ * cross-check: a vendor sending both and disagreeing is not something a client
+ * can adjudicate.
+ */
+function goWindow(source, kind, extra = {}) {
+	if (source === null || typeof source !== "object") return undefined;
+	const when = whenOf(source);
+
+	const percent = toNumber(pick(source, "percent", "usedPercent", "percentUsed"));
+	if (percent !== undefined) return { kind, usedPercent: percent, ...when, ...extra };
+	return fromCounts(source, kind, { ...when, ...extra });
+}
+
+export const OPENCODE_GO = {
+	label: "OpenCode Go",
+	/**
+	 * Fall back to the key the OpenCode client already holds.
+	 *
+	 * Only when the route carries no `apiKeyEnv`, only this one path, and only
+	 * to the vendor the file belongs to — the key goes back where it came from.
+	 * Every failure mode (absent, unreadable, not JSON, different shape) is the
+	 * same answer: no credential. The file is not ours and may change without
+	 * notice, so it must never be able to turn a working panel into an error.
+	 */
+	async localCredential({ readFile: read = readFile, homedir: home = homedir } = {}) {
+		try {
+			const raw = JSON.parse(await read(join(home(), ...OPENCODE_AUTH_PATH), "utf8"));
+			const entry = pick(raw, "opencode-go", "opencode");
+			return entry?.type === "api" ? label(entry.key) : undefined;
+		} catch {
+			return undefined;
+		}
+	},
+	async read({ origin, get }) {
+		const body = await get(new URL("/zen/go/v1/usage", origin).href);
+		const usage = body?.usage ?? body;
+		const windows = [
+			goWindow(pick(usage, "rolling", "session"), "session"),
+			goWindow(pick(usage, "weekly", "week"), "weekly"),
+			goWindow(pick(usage, "monthly", "month"), "monthly")
+		].filter(Boolean);
+		return {
+			plan: label(pick(usage, "plan", "planName")) ?? "Go",
+			isAvailable: windows.length === 0 ? undefined : windows.every((w) => (w.usedPercent ?? 0) < 100),
+			windows,
+			...(windows.length === 0 ? { reason: "no rolling/weekly/monthly usage in the response" } : {})
+		};
+	}
+};
+
+// --- Kimi For Coding -----------------------------------------------------------
+
+export const KIMI = {
+	label: "Kimi For Coding",
+	async read({ origin, get }) {
+		const body = await get(new URL("/coding/v1/usages", origin).href);
+		const data = body?.data ?? body;
+
+		// The short window arrives as a list, because a plan can carry several
+		// rate limits. The first one that yields a usable window is the one the
+		// panel can say something true about; the rest have no row to go in.
+		const limits = Array.isArray(data?.limits) ? data.limits : [];
+		const session = limits
+			.map((entry) => {
+				const detail = entry?.detail ?? entry;
+				return fromCounts(detail, "session", whenOf(detail));
+			})
+			.find(Boolean);
+		const weeklyDetail = pick(data, "usage", "weekly");
+		const weekly = fromCounts(weeklyDetail, "weekly", whenOf(weeklyDetail));
+		const windows = [session, weekly].filter(Boolean);
+
+		return {
+			plan: label(pick(data, "plan", "planName", "plan_name")) ?? "Kimi For Coding",
+			isAvailable: windows.length === 0 ? undefined : windows.some((w) => w.used < w.limit),
+			windows,
+			...(windows.length === 0 ? { reason: "no limits or usage counters in the response" } : {})
+		};
+	}
+};
+
+// --- MiniMax Coding Plan -------------------------------------------------------
+
+/** Which host serves the token-plan route, given the one the route points at. */
+const MINIMAX_SIBLING = new Map([
+	["api.minimax.io", "www.minimax.io"],
+	["www.minimax.io", "api.minimax.io"],
+	["api.minimaxi.com", "www.minimaxi.com"],
+	["www.minimaxi.com", "api.minimaxi.com"]
+]);
+
+/**
+ * Chat model names, for finding the entry the plan is actually about.
+ *
+ * The resource group used to be called `general`. Newer payloads name the entry
+ * after the model instead, so matching only `general` loses the whole card —
+ * silently, because an empty list is not an error.
+ */
+const MINIMAX_CHAT_MODEL = /^(minimax|abab|coding-plan)/i;
+
+/**
+ * The window status codes, as far as they can be told apart.
+ *
+ * 1 normal, 2 exhausted, 3 unlimited. Inferred, not published. The important
+ * part is what they are used FOR: they decide how a window renders, never
+ * whether it renders. Treating "status is 1" as the precondition for showing a
+ * window hides it in exactly the two states worth seeing — spent, and
+ * unmetered.
+ */
+function minimaxWindow(entry, prefix, kind, extra = {}) {
+	// Payloads have been seen in both spellings, so each field is looked up
+	// under `snake_case` and the camelCase of the same words.
+	const camel = (text) => text.replace(/_([a-z])/g, (_, char) => char.toUpperCase());
+	const at = (suffix) => pick(entry, `${prefix}_${suffix}`, camel(`${prefix}_${suffix}`));
+	const status = toNumber(at("status"));
+	if (status === 3) return { kind, unlimited: true, ...extra };
+
+	const remainingPercent = toNumber(at("remaining_percent"));
+	if (remainingPercent !== undefined) return { kind, remainingPercent, ...extra };
+
+	const total = toNumber(at("total_count"));
+	const usage = toNumber(at("usage_count"));
+	// Current payloads zero the counters and report only percentages, so a total
+	// of zero means "not reported here", not "no allowance".
+	if (total !== undefined && total > 0 && usage !== undefined) return { kind, used: usage, limit: total, ...extra };
+
+	// A window whose numbers are all missing is still worth a row when the
+	// status says it is spent — that is the state a user most needs to see.
+	return status === 2 ? { kind, usedPercent: 100, ...extra } : undefined;
+}
+
+export const MINIMAX = {
+	label: "MiniMax",
+	// Answers HTTP 200 for everything, including a bad key, and puts the verdict
+	// in `base_resp`. Verified against all four hosts. Its 404 is a real 404,
+	// which is what makes the host fallback below safe.
+	envelope: (body) => {
+		const code = toNumber(pick(body?.base_resp ?? body?.baseResp, "status_code", "statusCode"));
+		if (code === undefined || code === 0) return undefined;
+		const message = pick(body?.base_resp ?? body?.baseResp, "status_msg", "statusMsg");
+		return { status: code, message: label(message) };
+	},
+	async read({ origin, get }) {
+		const body = await readAcrossHosts(get, origin, "/v1/token_plan/remains");
+		const remains = Array.isArray(body?.model_remains)
+			? body.model_remains
+			: Array.isArray(body?.data?.model_remains)
+				? body.data.model_remains
+				: [];
+		if (remains.length === 0) return { plan: "MiniMax Coding Plan", reason: "response carries no model_remains entries" };
+
+		const nameOf = (entry) => String(pick(entry, "model_name", "modelName") ?? "");
+		const chat = remains.find((entry) => nameOf(entry).toLowerCase() === "general") ?? remains.find((entry) => MINIMAX_CHAT_MODEL.test(nameOf(entry)));
+		if (chat === undefined) return { plan: "MiniMax Coding Plan", reason: "model_remains has no general or chat-model entry" };
+
+		const windows = [
+			minimaxWindow(chat, "current_interval", "session", relativeReset(chat, "remains_time", "remainsTime")),
+			minimaxWindow(chat, "current_weekly", "weekly", relativeReset(chat, "weekly_remains_time", "weeklyRemainsTime"))
+		].filter(Boolean);
+
+		return {
+			plan: "MiniMax Coding Plan",
+			isAvailable: windows.length === 0 ? undefined : windows.some((w) => w.unlimited === true || (w.usedPercent ?? 0) < 100),
+			windows,
+			...(windows.length === 0 ? { reason: "the chat-model entry carries no usable quota fields" } : {})
+		};
+	}
+};
+
+/** `{ resetInMs }` from a "milliseconds remaining" field, if there is one. */
+function relativeReset(source, ...keys) {
+	const ms = toNumber(pick(source, ...keys));
+	return ms === undefined ? {} : { resetInMs: ms };
+}
+
+/**
+ * Try the route's own host, then its sibling.
+ *
+ * An account's plan endpoint is not always on the host its inference traffic
+ * uses. Only a 404, a 405 or a non-JSON reply moves on — those mean "this host
+ * does not serve it". A 401, a 403 or a 429 is a **real answer**: retrying it
+ * elsewhere cannot improve on it, and against a rate limiter it turns one
+ * refusal into two.
+ */
+async function readAcrossHosts(get, origin, path) {
+	const url = new URL(path, origin);
+	const sibling = MINIMAX_SIBLING.get(url.hostname.toLowerCase());
+	try {
+		return await get(url.href);
+	} catch (error) {
+		const elsewhere = error?.status === 404 || error?.status === 405 || error?.kind === "invalid-json";
+		if (sibling === undefined || !elsewhere) throw error;
+		url.hostname = sibling;
+		return get(url.href);
+	}
+}
+
+// --- Z.ai / 智谱 Coding Plan ----------------------------------------------------
+
+/**
+ * Z.ai's window-length unit codes, as far as they can be told apart.
+ *
+ * Inferred rather than published, so an unrecognised code yields no `minutes`
+ * at all. The window still renders — under its kind's own name — which is the
+ * right way for a guess to fail: losing the label "5-hour" costs a detail,
+ * inventing the wrong one costs trust in the number beside it.
+ */
+const ZAI_UNIT_MINUTES = new Map([
+	[5, 1],
+	[3, 60],
+	[1, 24 * 60],
+	[6, 7 * 24 * 60]
+]);
+
+/** How long one Z.ai limit's window is, in minutes, when that can be told. */
+function zaiMinutes(limit) {
+	const per = ZAI_UNIT_MINUTES.get(toNumber(pick(limit, "unit")));
+	const count = toNumber(pick(limit, "number"));
+	return per === undefined || count === undefined || count <= 0 ? undefined : per * count;
+}
+
+/**
+ * One limit row turned into window input, or undefined if it carries no fraction.
+ *
+ * `usage` on these rows is the **allowance**, not the amount consumed — the
+ * shared `fromCounts` reads that name the other way round, which is why this
+ * vendor spells the arithmetic out instead of reusing it.
+ */
+function zaiWindow(limit, kind) {
+	if (limit === null || typeof limit !== "object") return undefined;
+	const minutes = zaiMinutes(limit);
+	const at = pick(limit, "nextResetTime", "next_reset_time");
+	const extra = { ...(minutes === undefined ? {} : { minutes }), ...(at === undefined ? {} : { resetsAt: at }) };
+
+	const total = toNumber(pick(limit, "usage", "limit", "total"));
+	const remaining = toNumber(pick(limit, "remaining"));
+	const current = toNumber(pick(limit, "currentValue", "current_value"));
+	if (total !== undefined && total > 0) {
+		const used = remaining !== undefined ? total - remaining : current;
+		if (used !== undefined) return { kind, used, limit: total, ...extra };
+	}
+
+	const percent = toNumber(pick(limit, "percentage", "usedPercent", "used_percent"));
+	return percent === undefined ? undefined : { kind, usedPercent: percent, ...extra };
+}
+
+const ZAI_TOKEN_LIMITS = new Set(["TOKENS_LIMIT", "CREDIT_LIMIT"]);
+
+/**
+ * The Coding Plan's quota windows, and what the plan is called.
+ *
+ * Read alongside the wallet balance rather than instead of it: this vendor
+ * sells both, and an account can be holding a plan and a top-up at once. Either
+ * half failing leaves the other one showing.
+ */
+export async function readZaiCodingPlan({ origin, get }) {
+	const quota = await get(new URL("/api/monitor/usage/quota/limit", origin).href, { raw: true });
+	const limits = Array.isArray(quota?.data?.limits) ? quota.data.limits : [];
+	const typeOf = (limit) => String(pick(limit, "type", "limit_type") ?? "").toUpperCase();
+
+	// Sorted shortest-first so the rolling window and the long one land in the
+	// right rows whatever order they arrived in.
+	const token = limits
+		.filter((limit) => ZAI_TOKEN_LIMITS.has(typeOf(limit)))
+		.sort((a, b) => (zaiMinutes(a) ?? Number.MAX_SAFE_INTEGER) - (zaiMinutes(b) ?? Number.MAX_SAFE_INTEGER));
+
+	const windows = [
+		zaiWindow(token[0], "session"),
+		token.length > 1 ? zaiWindow(token[token.length - 1], "weekly") : undefined,
+		zaiWindow(limits.find((limit) => typeOf(limit) === "TIME_LIMIT"), "billing")
+	].filter(Boolean);
+
+	// The plan's name lives on a second route. It is a label, so its absence
+	// must not cost the quota that was already read.
+	let plan;
+	try {
+		const subscription = await get(new URL("/api/biz/subscription/list", origin).href, { raw: true });
+		const row = Array.isArray(subscription?.data) ? subscription.data[0] : subscription?.data;
+		plan = label(pick(row, "product_name", "productName", "plan_name", "planName", "package_name", "packageName"));
+	} catch {
+		// A plan with no name is still a plan.
+	}
+
+	return { windows, plan };
+}

--- a/test/balance.test.js
+++ b/test/balance.test.js
@@ -25,11 +25,22 @@ test("official is decided by origin, not by what the route is called", () => {
 });
 
 test("every scheme answers the same shape, so one card renders all of them", () => {
-	assert.deepEqual(Object.keys(SCHEMES).sort(), ["deepseek", "moonshot", "newapi", "openrouter", "sub2api", "zai"]);
+	assert.deepEqual(Object.keys(SCHEMES).sort(), [
+		"deepseek",
+		"kimi",
+		"minimax",
+		"moonshot",
+		"newapi",
+		"opencode-go",
+		"openrouter",
+		"sub2api",
+		"zai"
+	]);
 	for (const [name, spec] of Object.entries(SCHEMES)) {
 		assert.equal(typeof spec.read, "function", name);
 		assert.equal(typeof spec.label, "string", name);
 		if (spec.envelope !== undefined) assert.equal(typeof spec.envelope, "function", name);
+		if (spec.localCredential !== undefined) assert.equal(typeof spec.localCredential, "function", name);
 	}
 });
 

--- a/test/subscriptions.test.js
+++ b/test/subscriptions.test.js
@@ -1,0 +1,398 @@
+/**
+ * Vendors that sell a plan rather than a balance.
+ *
+ * These payloads have no published schema, and the readers were written
+ * defensively on purpose. Every test below names the specific way a naive
+ * reader loses the card — usually silently, because an empty list is not an
+ * error and a blank card looks like an account with nothing in it.
+ *
+ * Nothing here touches the network. What WAS checked live, with an invalid
+ * Bearer and a control path that does not exist:
+ *
+ *   GET https://opencode.ai/zen/go/v1/usage      -> 401 JSON  (404 -> HTML)
+ *   GET https://api.kimi.com/coding/v1/usages    -> 401 JSON  (404 -> JSON 404)
+ *   GET https://api.minimax.io/v1/token_plan/remains -> 200 + base_resp 1004
+ *   GET https://api.minimax.io/v1/nope-404       -> 404 "404 page not found"
+ *
+ * The MiniMax pair is the important one: a real 404 beside a 200-that-means-no
+ * is what makes the host fallback safe to attempt at all.
+ */
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { SCHEMES, readBalance } from "../src/balance.js";
+import { OPENCODE_GO } from "../src/subscriptions.js";
+
+const NOW = Date.UTC(2026, 7, 17, 12, 0, 0);
+
+/** Serve one body to every request. */
+const serve = (body) => async () => ({ ok: true, json: async () => body });
+
+/** Serve a different body per URL, and record what was asked for. */
+function router(routes) {
+	const seen = [];
+	const fetch = async (url, init) => {
+		seen.push({ url, authorization: init?.headers?.authorization });
+		const hit = Object.entries(routes).find(([fragment]) => url.includes(fragment));
+		if (hit === undefined) return { ok: false, status: 404 };
+		const answer = hit[1];
+		if (typeof answer === "function") return answer();
+		return { ok: true, json: async () => answer };
+	};
+	return { fetch, seen };
+}
+
+const read = (scheme, origin, fetch, extra = {}) =>
+	readBalance({ scheme, origin, apiKey: "k", now: NOW, fetch, ...extra });
+
+// --- OpenCode Go ---------------------------------------------------------------
+
+test("opencode-go reads its three rolling windows", async () => {
+	const result = await read(
+		"opencode-go",
+		"https://opencode.ai",
+		serve({ usage: { rolling: { percent: 4, resetInSec: 3600 }, weekly: { percent: 4 }, monthly: { percent: 2 } } })
+	);
+	assert.equal(result.fetched, true);
+	assert.equal(result.plan, "Go");
+	assert.deepEqual(result.windows, [
+		{ kind: "session", usedPercent: 4, resetsAt: "2026-08-17T13:00:00.000Z" },
+		{ kind: "weekly", usedPercent: 4 },
+		{ kind: "monthly", usedPercent: 2 }
+	]);
+});
+
+test("opencode-go accepts the payload flat as well as under `usage`", async () => {
+	const result = await read("opencode-go", "https://opencode.ai", serve({ rolling: { percent: 11 } }));
+	assert.deepEqual(result.windows, [{ kind: "session", usedPercent: 11 }]);
+});
+
+test("opencode-go falls back to counts when no percentage is sent", async () => {
+	const result = await read("opencode-go", "https://opencode.ai", serve({ usage: { weekly: { used: 250, limit: 1000 } } }));
+	assert.deepEqual(result.windows, [{ kind: "weekly", usedPercent: 25 }]);
+});
+
+test("a response with no recognisable windows says which fields were missing", async () => {
+	// The failure a blank card cannot express. Without this the user reports
+	// "it shows nothing" and there is no way to tell a wrong field name from an
+	// expired plan.
+	const result = await read("opencode-go", "https://opencode.ai", serve({ usage: { somethingElse: {} } }));
+	assert.equal(result.fetched, true);
+	assert.equal("windows" in result, false, "not an empty list");
+	assert.match(result.reason, /rolling/);
+});
+
+test("the local OpenCode key is used only when the route carries none", async () => {
+	const auth = JSON.stringify({ "opencode-go": { type: "api", key: "  local-key  " } });
+	const deps = { readFile: async () => auth, homedir: () => "/home/someone" };
+
+	const withRoute = router({ usage: { usage: { rolling: { percent: 1 } } } });
+	await read("opencode-go", "https://opencode.ai", withRoute.fetch, deps);
+	assert.equal(withRoute.seen[0].authorization, "Bearer k", "a configured key is never second-guessed");
+
+	const withoutRoute = router({ usage: { usage: { rolling: { percent: 1 } } } });
+	await readBalance({ scheme: "opencode-go", origin: "https://opencode.ai", now: NOW, fetch: withoutRoute.fetch, ...deps });
+	assert.equal(withoutRoute.seen[0].authorization, "Bearer local-key", "trimmed, and used");
+});
+
+test("every way the local key file can fail reads as 'no credential'", async () => {
+	// The file is not ours and may change shape without notice. It must never be
+	// able to turn a working panel into an error.
+	const failures = [
+		{ readFile: async () => { throw new Error("ENOENT"); } },
+		{ readFile: async () => "not json at all" },
+		{ readFile: async () => JSON.stringify({ "opencode-go": { type: "oauth", key: "x" } }) },
+		{ readFile: async () => JSON.stringify({ "opencode-go": { type: "api", key: "   " } }) },
+		{ readFile: async () => JSON.stringify({ somethingElse: 1 }) }
+	];
+	for (const deps of failures) {
+		assert.equal(await OPENCODE_GO.localCredential({ ...deps, homedir: () => "/home/someone" }), undefined);
+		const result = await readBalance({
+			scheme: "opencode-go",
+			origin: "https://opencode.ai",
+			fetch: () => assert.fail("no request may be made without a key"),
+			homedir: () => "/home/someone",
+			...deps
+		});
+		assert.equal(result.reason, "no-credential");
+	}
+});
+
+// --- Kimi For Coding -----------------------------------------------------------
+
+test("kimi reads the first usable rate limit and the weekly counter", async () => {
+	const result = await read(
+		"kimi",
+		"https://api.kimi.com",
+		serve({
+			data: {
+				plan: "Kimi For Coding Pro",
+				limits: [{ detail: { note: "no counters here" } }, { detail: { limit: 100, remaining: 40, resetTime: "2026-08-17T14:00:00Z" } }],
+				usage: { limit: 1000, remaining: 250 }
+			}
+		})
+	);
+	assert.equal(result.plan, "Kimi For Coding Pro");
+	assert.deepEqual(result.windows, [
+		{ kind: "session", usedPercent: 60, resetsAt: "2026-08-17T14:00:00.000Z" },
+		{ kind: "weekly", usedPercent: 75 }
+	]);
+});
+
+test("kimi tolerates the limits list being flat rather than wrapped in `detail`", async () => {
+	const result = await read("kimi", "https://api.kimi.com", serve({ limits: [{ limit: 10, remaining: 1 }] }));
+	assert.deepEqual(result.windows, [{ kind: "session", usedPercent: 90 }]);
+});
+
+// --- MiniMax -------------------------------------------------------------------
+
+/** One `model_remains` entry, in the shape the endpoint documents nowhere. */
+const remains = (over = {}) => ({
+	model_name: "general",
+	current_interval_status: 1,
+	current_interval_remaining_percent: 96,
+	current_weekly_status: 1,
+	current_weekly_remaining_percent: 40,
+	...over
+});
+
+test("minimax turns remaining percentages into used ones", async () => {
+	const result = await read("minimax", "https://api.minimax.io", serve({ model_remains: [remains()] }));
+	assert.deepEqual(result.windows, [
+		{ kind: "session", usedPercent: 4 },
+		{ kind: "weekly", usedPercent: 60 }
+	]);
+});
+
+test("minimax finds the chat entry when it is named after the model", async () => {
+	// Older payloads called the resource group `general`. Newer ones use the
+	// model name. Matching only `general` loses every window on a new account,
+	// with no error anywhere.
+	const result = await read("minimax", "https://api.minimax.io", serve({ model_remains: [remains({ model_name: "MiniMax-M3" })] }));
+	assert.equal(result.windows.length, 2);
+});
+
+test("minimax keeps a window whose status is exhausted or unlimited", async () => {
+	// Status decides HOW a window renders, never WHETHER it renders. Requiring
+	// status 1 hides the window in exactly the two states worth seeing.
+	const spent = await read(
+		"minimax",
+		"https://api.minimax.io",
+		serve({ model_remains: [remains({ current_weekly_status: 2, current_weekly_remaining_percent: undefined })] })
+	);
+	assert.deepEqual(spent.windows.at(-1), { kind: "weekly", usedPercent: 100 });
+
+	const unmetered = await read(
+		"minimax",
+		"https://api.minimax.io",
+		serve({ model_remains: [remains({ current_weekly_status: 3, current_weekly_remaining_percent: undefined })] })
+	);
+	assert.deepEqual(unmetered.windows.at(-1), { kind: "weekly", unlimited: true });
+});
+
+test("minimax reads camelCase payloads as well as snake_case ones", async () => {
+	const result = await read(
+		"minimax",
+		"https://api.minimax.io",
+		serve({ model_remains: [{ modelName: "MiniMax-M3", currentIntervalRemainingPercent: 30 }] })
+	);
+	assert.deepEqual(result.windows, [{ kind: "session", usedPercent: 70 }]);
+});
+
+test("minimax counters are only trusted when the total is above zero", async () => {
+	// Current payloads zero the counters and report percentages instead. A total
+	// of zero means "not reported here", and dividing by it says "spent".
+	const zeroed = await read(
+		"minimax",
+		"https://api.minimax.io",
+		serve({ model_remains: [remains({ current_interval_remaining_percent: undefined, current_interval_total_count: 0, current_interval_usage_count: 0 })] })
+	);
+	assert.equal(zeroed.windows.some((w) => w.kind === "session"), false);
+
+	const real = await read(
+		"minimax",
+		"https://api.minimax.io",
+		serve({ model_remains: [remains({ current_interval_remaining_percent: undefined, current_interval_total_count: 200, current_interval_usage_count: 50 })] })
+	);
+	assert.deepEqual(real.windows[0], { kind: "session", usedPercent: 25 });
+});
+
+test("minimax refuses with a 200, and the envelope catches it", async () => {
+	const result = await read(
+		"minimax",
+		"https://api.minimax.io",
+		serve({ base_resp: { status_code: 1004, status_msg: "login fail: Please carry the API secret key" } })
+	);
+	assert.equal(result.fetched, false);
+	assert.equal(result.reason, "upstream-1004");
+});
+
+test("minimax tries its sibling host on a 404, and only on a 404", async () => {
+	// A 404 or a non-JSON reply means this host does not serve the route. A 401,
+	// a 403 or a 429 is a real answer — retrying it elsewhere cannot improve on
+	// it, and against a rate limiter it turns one refusal into two.
+	const found = router({
+		"api.minimax.io": () => ({ ok: false, status: 404 }),
+		"www.minimax.io": { model_remains: [remains()] }
+	});
+	const result = await read("minimax", "https://api.minimax.io", found.fetch);
+	assert.equal(result.fetched, true);
+	assert.deepEqual(found.seen.map((r) => new URL(r.url).hostname), ["api.minimax.io", "www.minimax.io"]);
+
+	for (const status of [401, 403, 429]) {
+		const refused = router({ "api.minimax.io": () => ({ ok: false, status }) });
+		const answer = await read("minimax", "https://api.minimax.io", refused.fetch);
+		assert.equal(answer.reason, `http-${status}`);
+		assert.equal(refused.seen.length, 1, `a ${status} is an answer, not a reason to ask elsewhere`);
+	}
+});
+
+test("minimax moves on when a host answers something that is not JSON", async () => {
+	const html = router({
+		"api.minimaxi.com": () => ({ ok: true, json: async () => { throw new SyntaxError("Unexpected token <"); } }),
+		"www.minimaxi.com": { model_remains: [remains()] }
+	});
+	assert.equal((await read("minimax", "https://api.minimaxi.com", html.fetch)).fetched, true);
+	assert.equal(html.seen.length, 2);
+});
+
+test("a host with no sibling reports the failure rather than inventing one", async () => {
+	const result = await read("minimax", "https://minimax.example", async () => ({ ok: false, status: 404 }));
+	assert.equal(result.reason, "http-404");
+});
+
+test("non-JSON from a scheme with nowhere else to look is its own reason", async () => {
+	const result = await read("kimi", "https://api.kimi.com", async () => ({
+		ok: true,
+		json: async () => { throw new SyntaxError("Unexpected token <"); }
+	}));
+	assert.equal(result.reason, "invalid-response", "distinct from a timeout and from an unreachable host");
+});
+
+// --- Z.ai / 智谱 ----------------------------------------------------------------
+
+const zaiQuota = {
+	data: {
+		limits: [
+			{ type: "TOKENS_LIMIT", unit: 3, number: 5, usage: 1000, remaining: 960, nextResetTime: "2026-08-17T17:00:00Z" },
+			{ type: "TOKENS_LIMIT", unit: 6, number: 1, usage: 50000, remaining: 10000 },
+			{ type: "TIME_LIMIT", usage: 30, remaining: 12 }
+		]
+	}
+};
+
+test("zai reads its coding plan alongside its wallet, because an account can hold both", async () => {
+	const { fetch } = router({
+		"/api/paas/v4/balance": { data: { total_balance: 100, available_balance: 64 } },
+		"/api/monitor/usage/quota/limit": zaiQuota,
+		"/api/biz/subscription/list": { data: [{ product_name: "GLM Coding Max" }] }
+	});
+	const result = await read("zai", "https://api.z.ai", fetch);
+	assert.equal(result.total, 64, "the wallet is still read");
+	assert.equal(result.plan, "GLM Coding Max");
+	assert.deepEqual(result.windows, [
+		{ kind: "session", minutes: 300, usedPercent: 4, resetsAt: "2026-08-17T17:00:00.000Z" },
+		{ kind: "weekly", minutes: 10080, usedPercent: 80 },
+		{ kind: "billing", usedPercent: 60 }
+	]);
+});
+
+test("zai's console routes get the bare key, and the inference route the Bearer one", async () => {
+	// Different API surfaces on one host want different auth. Sending the wrong
+	// one is a 401 that looks exactly like a bad key.
+	const { fetch, seen } = router({
+		"/api/paas/v4/balance": { data: { available_balance: 1 } },
+		"/api/monitor/usage/quota/limit": zaiQuota,
+		"/api/biz/subscription/list": { data: [] }
+	});
+	await read("zai", "https://api.z.ai", fetch);
+	const authOf = (fragment) => seen.find((r) => r.url.includes(fragment)).authorization;
+	assert.equal(authOf("/api/paas/v4/balance"), "Bearer k");
+	assert.equal(authOf("/api/monitor/"), "k");
+	assert.equal(authOf("/api/biz/"), "k");
+});
+
+test("either half of a zai account can fail without taking the other down", async () => {
+	const walletOnly = router({ "/api/paas/v4/balance": { data: { available_balance: 42 } } });
+	const wallet = await read("zai", "https://api.z.ai", walletOnly.fetch);
+	assert.equal(wallet.total, 42);
+	assert.equal("windows" in wallet, false);
+
+	const planOnly = router({ "/api/monitor/usage/quota/limit": zaiQuota, "/api/biz/subscription/list": { data: [] } });
+	const plan = await read("zai", "https://api.z.ai", planOnly.fetch);
+	assert.equal(plan.total, undefined);
+	assert.equal(plan.windows.length, 3);
+});
+
+test("both halves failing is a failure, not a card with nothing on it", async () => {
+	const result = await read("zai", "https://api.z.ai", async () => ({ ok: false, status: 401 }));
+	assert.equal(result.fetched, false);
+	assert.equal(result.reason, "http-401");
+});
+
+test("a window length nobody can decode costs the label, not the number", async () => {
+	// The unit codes are inferred, not published. An unrecognised one yields no
+	// `minutes`, and the row still renders under its kind's own name — the right
+	// way for a guess to fail.
+	const { fetch } = router({
+		"/api/monitor/usage/quota/limit": { data: { limits: [{ type: "TOKENS_LIMIT", unit: 99, number: 7, usage: 10, remaining: 3 }] } },
+		"/api/biz/subscription/list": { data: [] }
+	});
+	const result = await read("zai", "https://api.z.ai", fetch);
+	assert.deepEqual(result.windows, [{ kind: "session", usedPercent: 70 }]);
+});
+
+test("zai's `usage` is the allowance, not the amount consumed", async () => {
+	// The shared count helper reads `usage` the other way round, which is why
+	// this vendor spells the arithmetic out. Getting it backwards turns a 4%
+	// window into a 96% one.
+	const { fetch } = router({
+		"/api/monitor/usage/quota/limit": { data: { limits: [{ type: "CREDIT_LIMIT", usage: 1000, remaining: 960 }] } },
+		"/api/biz/subscription/list": { data: [] }
+	});
+	assert.equal((await read("zai", "https://api.z.ai", fetch)).windows[0].usedPercent, 4);
+});
+
+test("a plan whose name cannot be read is still a plan", async () => {
+	const { fetch } = router({
+		"/api/monitor/usage/quota/limit": zaiQuota,
+		"/api/biz/subscription/list": () => ({ ok: false, status: 403 })
+	});
+	const result = await read("zai", "https://api.z.ai", fetch);
+	assert.equal(result.plan, undefined);
+	assert.equal(result.windows.length, 3, "the quota was already read and must not be thrown away");
+});
+
+// --- the registry ---------------------------------------------------------------
+
+test("every plan vendor is reached by origin, never by what the route is called", async () => {
+	// Same rule as site attribution: a route named `kimi` may point anywhere,
+	// and a route named anything may point at Kimi.
+	const { listAccounts } = await import("../src/balance.js");
+	const ctx = {
+		get: (name) =>
+			name === "llm"
+				? { listConfigurableProviders: () => [
+						{ provider: "a", settingsNs: "ns", settingsPath: ["a"] },
+						{ provider: "b", settingsNs: "ns", settingsPath: ["b"] },
+						{ provider: "c", settingsNs: "ns", settingsPath: ["c"] },
+						{ provider: "d", settingsNs: "ns", settingsPath: ["d"] }
+					] }
+				: { get: () => ({
+						a: { baseURL: "https://opencode.ai/zen/v1", apiKeyEnv: "K" },
+						b: { baseURL: "https://api.kimi.com/coding/v1", apiKeyEnv: "K" },
+						c: { baseURL: "https://api.minimax.io/v1", apiKeyEnv: "K" },
+						d: { baseURL: "https://api.minimaxi.com/v1", apiKeyEnv: "K" }
+					}) }
+	};
+	assert.deepEqual(listAccounts(ctx).map((a) => a.scheme), ["opencode-go", "kimi", "minimax", "minimax"]);
+	assert.deepEqual(listAccounts(ctx).map((a) => a.displayName), ["OpenCode Go", "Kimi For Coding", "MiniMax", "MiniMax"]);
+});
+
+test("only the scheme that has a local key file declares one", async () => {
+	// Reading a credential off disk is a capability, not a convenience to spread
+	// around. Every other scheme must go through the credentials seam.
+	const withLocal = Object.entries(SCHEMES).filter(([, spec]) => spec.localCredential !== undefined);
+	assert.deepEqual(withLocal.map(([name]) => name), ["opencode-go"]);
+});


### PR DESCRIPTION
Closes #12。依赖 #11 的数据模型和 #9 的 envelope 机制，两个都已合并。

## 加了什么

新模块 `src/subscriptions.js`，四家：

| Provider | 端点 | 鉴权 |
| --- | --- | --- |
| OpenCode Go | `/zen/go/v1/usage` | `Bearer`，路由没配 key 时退回本机 `auth.json` |
| Kimi For Coding | `/coding/v1/usages` | `Bearer` |
| MiniMax Coding Plan | `/v1/token_plan/remains` | `Bearer`，四主机互为备选 |
| Z.ai / 智谱 Coding Plan | `/api/monitor/usage/quota/limit` + `/api/biz/subscription/list` | **裸密钥** |

全部按 **origin** 匹配，和站点归属同一条规则：叫 `kimi` 的路由可能指向任何地方，指向 Kimi 的路由可能叫任何名字。

## Z.ai 两半都读

这家既卖钱包又卖 Coding Plan，一个账户可以两样都有，所以两个请求并发发出，**任一边失败不影响另一边**：套餐用户钱包是空的，不该看到一张空卡；钱包用户没有套餐，也不该因为第二个路由 404 就把余额弄丢。两边都失败才算失败。

顺带：它的 console 路由要**裸密钥**，而推理 API 要 `Bearer`。同一个域名两套 API 面，发错了就是一个和"key 不对"长得一模一样的 401。`get()` 因此多了个 `raw` 选项，密钥仍然只走 Authorization 头。

## 关于"验证过"这件事，说清楚

**实测过的**（无效 key + 不存在的路径做对照）：哪个主机在服务这个路由、每家用什么方式拒绝、状态码是否携带信息。

```
GET https://opencode.ai/zen/go/v1/usage           -> 401 JSON  （404 对照 -> HTML）
GET https://api.kimi.com/coding/v1/usages         -> 401 JSON  （404 对照 -> JSON 404）
GET https://api.minimax.io/v1/token_plan/remains  -> 200 + base_resp.status_code 1004
GET https://api.minimax.io/v1/nope-404            -> 404 "404 page not found"
```

MiniMax 那一对是关键：一个"真 404"挨着一个"200 其实是拒绝"，正是这个组合让换主机重试成为安全操作。

**没能验证的**：成功响应的字段布局——手上没有这四家的付费账户。所以每个 reader 都写成**失败时给出一句话**而不是留空卡，面板把它印出来。这几家接口都没有公开 schema，字段一定会漂；"它什么都不显示"不是一份能处理的报告。

## 防御性解析，逐条对应它防的东西

- **MiniMax 的聊天条目**曾经叫 `general`，新版直接用模型名。只认 `general` 会让新账户**一个窗口都不剩**，而且没有任何报错。
- **窗口状态是枚举不是布尔。** 它决定窗口**怎么显示**，不决定**显不显示**。要求"状态正常"会在耗尽和不限量这两种最该看见的状态下把整行藏起来。
- **计数器归零** = 没上报，不是用光了。总数为 0 时除下去是"已用 100%"。
- **换主机只在 404 / 405 / 非 JSON 时发生。** 401、403、429 是真实答案，换个主机问不出更好的结果，而对着一个刚刚限流的接口重试等于把一次拒绝变成两次。
- **Z.ai 的 `usage` 是额度总量，不是已用量**。读反了，一个 4% 的窗口会显示成 96%。共用的计数辅助函数正好把这个字段名当"已用"，所以这家自己把算式写开了。
- **Z.ai 的单位码是推的，不是公开的。** 认不出的码就不给 `minutes`，这一行仍然按种类名渲染。猜错应该只损失一个标签，不该动旁边那个数字。

## 本机 auth.json

只在路由没配 `apiKeyEnv` 时读，只读那一个路径，key 只发回它本来的来处（opencode.ai）。文件不存在、读不动、不是 JSON、结构变了——**全部是同一个答案：没有凭据**，安静退回。这个文件不属于我们，不能让它把一块能用的面板变成一个报错。

## 界面

- 新增 `balance.unparsed` 文案（中英）：请求成功但一个字段都没认出来时，把 reader 找过哪儿说出来。
- 卡片副标题不再在没有对应标签时打印 scheme 的内部 id——原来会渲染成 "OpenCode Go · opencode-go"。

## 测试

`test/subscriptions.test.js` 27 个，上面每一条坑都有一个直接针对它的测试，测试名字说得出它在防什么。总计 **326 全绿**，不打任何真实网络。

## 顺带

README 的 Providers 表补了四行 + 订阅那一档的说明；`package.json` 加了 `./subscriptions` 子路径。
