### PR TITLE
feat: 声明式端点——内置表之外的供应商也能读余额/配额

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,43 @@ tokenledger:
   fingerprint: false
 ```
 
+### 自己声明一个余额接口 / Declared endpoints
+
+内置表覆盖不到的供应商，可以自己声明它的接口，不用等我们发版本：
+
+```yaml
+tokenledger:
+  endpoints:
+    - origin: https://relay.example.com   # 必须是你已配置的某条 provider 的同源地址
+      displayName: 我的中转站
+      path: /api/quota
+      # raw: true    # 有些控制台接口要裸密钥，不要 Bearer 前缀
+      fields:        # 值是响应 JSON 里的取值路径，不是表达式
+        total: data.balance
+        granted: data.total
+        used: data.used
+        currency: data.unit
+        plan: data.plan_name
+      windows:
+        - kind: weekly          # session / daily / weekly / monthly / billing
+          usedPercent: data.week.percent
+          resetsAt: data.week.reset_at
+```
+
+`fields` 和 `windows` 里写的是**取值路径**——描述"数字在哪儿"，不描述"怎么取"。没有表达式，也没有任何东西会被求值。路径写错只会让那个字段缺席，其余照常显示。
+
+这个功能等于让配置文件决定"往哪儿发一个带密钥的请求"，所以边界写死在代码里，不靠自觉：
+
+- **请求发往匹配到的那条 provider 的 origin**，`origin:` 字段只是用来找它的键。声明一个没配过的地址，不会产生任何请求。
+- `path` 必须是**单斜杠开头的绝对路径**。`//host/x` 是协议相对 URL，会解析到别的主机上；构造完还会再校验一次 origin。
+- **只发 GET**，没有请求体，声明里的 method / headers 一概不生效。
+- **密钥仍然只从那条 provider 自己的 `apiKeyEnv` 取**，声明不能指定任何凭据。
+- **跨源重定向直接失败**，不跟随——那是绕过第一条最省事的办法。
+- **响应体有大小上限和超时**。
+- **不能覆盖内置读法**：只在内置表答不上来时才轮到它。
+
+这类卡片会标注「自定义端点」，因为数字是你自己配的路径取出来的——取错了是配置问题，界面得让这一点看得出来。
+
 ## 正确性与数据口径 / Correctness
 
 用量折叠有三个地方容易错，都有测试覆盖（`test/usage.test.js`）：

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     ".": "./src/index.js",
     "./adapters/detect": "./src/adapters/detect.js",
     "./balance": "./src/balance.js",
+    "./declarative": "./src/declarative.js",
     "./client": "./src/client.js",
     "./discovery": "./src/discovery.js",
     "./fingerprints": "./src/fingerprints.js",

--- a/src/balance.js
+++ b/src/balance.js
@@ -43,6 +43,7 @@
  */
 
 import { detectRelaySoftware } from "./adapters/detect.js";
+import { compileEndpoint, indexEndpoints } from "./declarative.js";
 import { normalizeWindows } from "./quota.js";
 import { normalizeOrigin } from "./relay-sites.js";
 import { KIMI, MINIMAX, OPENCODE_GO, readZaiCodingPlan } from "./subscriptions.js";
@@ -109,6 +110,74 @@ export function vendorOf(baseUrl) {
 	} catch {
 		return undefined;
 	}
+}
+
+/** How many hops to follow before giving up on a same-origin redirect loop. */
+const MAX_REDIRECTS = 3;
+
+/**
+ * Fetch, following redirects only while they stay on the same origin.
+ *
+ * The default `follow` sends the Authorization header wherever the redirect
+ * points, so a relay that answers `302 https://collector.example/` is handed
+ * the user's key. That is the cheapest way around every other rule this module
+ * has, and it costs one option to close: take the hops manually and stop at the
+ * first one that changes origin.
+ *
+ * A stub `fetch` in a test returns no `status` and no `headers`, so the 3xx
+ * branch is simply never entered.
+ */
+async function fetchNoCrossOriginRedirect(doFetch, url, init) {
+	let current = url;
+	for (let hop = 0; ; hop++) {
+		const response = await doFetch(current, { ...init, redirect: "manual" });
+		const status = response?.status;
+		if (status !== 301 && status !== 302 && status !== 303 && status !== 307 && status !== 308) return response;
+
+		const location = response.headers?.get?.("location");
+		if (location === undefined || location === null || location === "" || hop >= MAX_REDIRECTS) {
+			throw Object.assign(new Error(`http-${status}`), { status });
+		}
+		const next = new URL(location, current);
+		if (next.origin !== new URL(current).origin) {
+			// Not a transport failure — a refusal to hand the credential over.
+			throw Object.assign(new Error("cross-origin-redirect"), { kind: "cross-origin-redirect" });
+		}
+		current = next.href;
+	}
+}
+
+/**
+ * Read a response body with a byte ceiling.
+ *
+ * A declared endpoint is not one of ours, so its answer is not assumed to be a
+ * reasonable size. Streamed where the runtime gives us a reader — which is what
+ * actually bounds the cost — and length-checked otherwise, which at least
+ * bounds the parse.
+ */
+async function readCapped(response, maxBytes) {
+	const tooLarge = () => Object.assign(new Error("response-too-large"), { kind: "too-large" });
+
+	const reader = response.body?.getReader?.();
+	if (reader === undefined || reader === null) {
+		const text = await response.text();
+		if (text.length > maxBytes) throw tooLarge();
+		return text;
+	}
+
+	const chunks = [];
+	let size = 0;
+	for (;;) {
+		const { done, value } = await reader.read();
+		if (done) break;
+		size += value.byteLength;
+		if (size > maxBytes) {
+			await reader.cancel().catch(() => {});
+			throw tooLarge();
+		}
+		chunks.push(value);
+	}
+	return Buffer.concat(chunks).toString("utf8");
 }
 
 /** A trimmed non-empty string, or undefined. */
@@ -454,7 +523,9 @@ export const SCHEMES = {
  */
 export async function readBalance(options = {}) {
 	const { scheme, origin, timeoutMs = 15_000 } = options;
-	const spec = SCHEMES[scheme];
+	// A compiled declaration is passed in rather than registered, because
+	// registering it would let it collide with — or replace — a built-in name.
+	const spec = options.spec ?? SCHEMES[scheme];
 	if (spec === undefined) return { supported: false, reason: "unknown-software" };
 
 	// A scheme may know where its vendor's own client already keeps a key. Only
@@ -477,8 +548,9 @@ export async function readBalance(options = {}) {
 	 *   routes want even though their inference API does not. Either way the key
 	 *   rides the Authorization header and never a query string.
 	 */
-	const get = async (url, { anonymous = false, raw = false } = {}) => {
-		const response = await doFetch(url, {
+	const get = async (url, options = {}) => {
+		const { anonymous = false, raw = false, maxBytes } = options;
+		const response = await fetchNoCrossOriginRedirect(doFetch, url, {
 			headers: anonymous
 				? { accept: "application/json" }
 				: { authorization: raw ? apiKey : `Bearer ${apiKey}`, accept: "application/json" },
@@ -487,8 +559,9 @@ export async function readBalance(options = {}) {
 		if (!response.ok) throw Object.assign(new Error(`http-${response.status}`), { status: response.status });
 		let body;
 		try {
-			body = await response.json();
-		} catch {
+			body = maxBytes === undefined ? await response.json() : JSON.parse(await readCapped(response, maxBytes));
+		} catch (error) {
+			if (error?.kind === "too-large") throw error;
 			// A host that answers HTML where JSON was asked for is not serving
 			// this route. Marked rather than thrown bare, so a reader that has a
 			// second host to try can tell that apart from a real refusal.
@@ -527,9 +600,13 @@ export async function readBalance(options = {}) {
 					? `http-${error.status}`
 					: error?.kind === "invalid-json"
 						? "invalid-response"
-						: error?.name === "AbortError"
-							? "timeout"
-							: "unreachable";
+						: // These three are refusals by this module, not by the
+							// endpoint, and the card has to be able to say which.
+							error?.kind === "cross-origin-redirect" || error?.kind === "too-large" || error?.kind === "declaration"
+							? error.kind
+							: error?.name === "AbortError"
+								? "timeout"
+								: "unreachable";
 		// A scheme whose endpoint wants a different credential from the one the
 		// route carries says so, rather than leaving the card on a bare 401 that
 		// reads as "your key is wrong".
@@ -662,8 +739,16 @@ export function createBalanceReader(ctx, options = {}) {
 				// Leave it unknown; the answer below says so.
 			}
 		}
+		// A user declaration is the last thing consulted, never the first. It
+		// cannot shadow a built-in scheme, so declaring an endpoint can add a
+		// vendor and can never change how a known one is read.
+		let declared;
 		if (scheme === undefined || SCHEMES[scheme] === undefined) {
-			return { ok: true, account: account.id, supported: false, reason: "unknown-software" };
+			declared = compileEndpoint(indexEndpoints(options.endpoints).get(account.origin));
+			if (declared === undefined) {
+				return { ok: true, account: account.id, supported: false, reason: "unknown-software" };
+			}
+			scheme = "declared";
 		}
 
 		const credentials = typeof ctx.get === "function" ? ctx.get("credentials") : undefined;
@@ -679,7 +764,11 @@ export function createBalanceReader(ctx, options = {}) {
 			ok: true,
 			account: account.id,
 			displayName: account.displayName,
-			...(await readBalance({ scheme, origin: account.origin, apiKey, fetch: options.fetch }))
+			...(await readBalance({ scheme, spec: declared, origin: account.origin, apiKey, fetch: options.fetch })),
+			// So the card can say the numbers came out of paths the user wrote.
+			// A wrong path is a configuration mistake, and that has to be
+			// distinguishable from the plugin getting a known vendor wrong.
+			...(declared === undefined ? {} : { declared: true })
 		};
 	};
 }

--- a/src/client.js
+++ b/src/client.js
@@ -1229,6 +1229,11 @@ window.__ModuleLoader__.load({
 			const amountLabel = typeof balance.total === "number" ? undefined : spent ? translate("balance.spent") : undefined;
 
 			const notes = [];
+			// Say it first. These numbers came out of paths the user wrote, so a
+			// wrong one is a configuration mistake — and that has to be
+			// distinguishable from the plugin misreading a vendor it claims to
+			// support, or the first bug report will be filed against us.
+			if (balance.declared === true) notes.push(translate("balance.declared"));
 			if (balance.unlimited === true) notes.push(translate("balance.unlimited"));
 			if (typeof balance.expiresAt === "number") {
 				notes.push(translate("balance.expires", { at: new Date(balance.expiresAt * 1000).toLocaleDateString() }));
@@ -1614,6 +1619,7 @@ window.__ModuleLoader__.load({
 			"table.none": "没有模型记录。",
 			"balance.account": "账户",
 			"balance.plan": "套餐 {plan}",
+			"balance.declared": "自定义端点",
 			"balance.unlimited": "不限额度",
 			"balance.quota": "{n} 额度",
 			"balance.spent": "已用",
@@ -1704,6 +1710,7 @@ window.__ModuleLoader__.load({
 			"table.none": "No model records.",
 			"balance.account": "Account",
 			"balance.plan": "{plan} plan",
+			"balance.declared": "declared endpoint",
 			"balance.unlimited": "Unlimited",
 			"balance.quota": "{n} quota",
 			"balance.spent": "spent",

--- a/src/declarative.js
+++ b/src/declarative.js
@@ -1,0 +1,171 @@
+/**
+ * Endpoints a user declares, for vendors nobody has written a reader for.
+ *
+ * ## Why this exists
+ *
+ * The built-in table has a ceiling. There are far more relays than anyone can
+ * ship readers for, and their balance endpoints are nearly all the same thing:
+ * one GET, one JSON body, a few numbers inside it. Opening an issue, cutting a
+ * release and waiting for an upgrade is an absurd amount of machinery for that.
+ *
+ * A declaration says where the numbers are, not how to go and get them. There
+ * is no expression language and nothing is evaluated: `fields` and `windows`
+ * hold dotted paths into the response, and the only operation is "walk down".
+ *
+ * ## The boundary, and why it is in code rather than in advice
+ *
+ * This feature lets a configuration file decide where a request carrying the
+ * user's API key gets sent. That is the whole risk, and none of it is mitigated
+ * by telling people to be careful:
+ *
+ * 1. **The URL is built from the ACCOUNT's origin, never the declaration's.**
+ *    The declared origin is only a lookup key — matched against origins that
+ *    are already in the user's own provider configuration. Nothing here can
+ *    name a host the harness was not already talking to.
+ * 2. **`path` must be a single-slash absolute path.** `//evil.example/x` is a
+ *    protocol-relative URL, and `new URL()` resolves it to a different host
+ *    entirely. The origin is re-checked after construction anyway, so this is
+ *    belt and braces on purpose.
+ * 3. **Only GET.** No body, no method, no headers from the declaration.
+ * 4. **The credential still comes from the route's own `apiKeyEnv`** and is
+ *    resolved by the same seam as everything else. A declaration cannot name a
+ *    credential, its own or anyone else's.
+ * 5. **Cross-origin redirects fail instead of being followed** — see `http` in
+ *    `balance.js`. Following one is the cheapest possible way around rule 1.
+ * 6. **Bounded body and a shared timeout**, so a hostile or broken endpoint
+ *    cannot hold the panel open or exhaust memory.
+ * 7. **A declaration cannot shadow a built-in scheme.** It is consulted only
+ *    where nothing else could answer, so no declaration can change how a known
+ *    vendor is read.
+ *
+ * @module dsh-tokenledger/declarative
+ */
+
+import { normalizeOrigin } from "./relay-sites.js";
+
+/** Keys that reach the prototype chain rather than the parsed document. */
+const FORBIDDEN = new Set(["__proto__", "constructor", "prototype"]);
+
+/**
+ * Walk a dotted path into a parsed body.
+ *
+ * Every failure is the same answer — `undefined` — because a path that does not
+ * match is a field this response does not carry, which is a fact the card
+ * already knows how to render. It is not an error, and it must not cost the
+ * fields that did resolve.
+ */
+export function readPath(body, path) {
+	if (typeof path !== "string" || path === "") return undefined;
+	let cursor = body;
+	for (const segment of path.split(".")) {
+		if (cursor === null || typeof cursor !== "object") return undefined;
+		if (FORBIDDEN.has(segment)) return undefined;
+		cursor = cursor[segment];
+	}
+	return cursor;
+}
+
+/** Numbers arrive as strings often enough to be worth handling once. */
+function toNumber(value) {
+	if (typeof value === "number" && Number.isFinite(value)) return value;
+	if (typeof value === "string" && value.trim() !== "") {
+		const parsed = Number(value);
+		if (Number.isFinite(parsed)) return parsed;
+	}
+	return undefined;
+}
+
+/** The four money fields, each read only if the declaration named a path. */
+const AMOUNT_FIELDS = ["total", "granted", "used"];
+
+/** Which window inputs are paths into the body, as opposed to literal values. */
+const WINDOW_PATHS = ["usedPercent", "usedRatio", "remainingPercent", "used", "limit", "resetsAt", "resetInSeconds"];
+
+/**
+ * Turn one declaration into something `SCHEMES` can hold.
+ *
+ * @param declaration - `{ displayName, path, raw?, fields?, windows? }`.
+ * @returns a scheme, or `undefined` when the declaration cannot be honoured
+ *   safely. A rejected declaration leaves the account reading "unsupported",
+ *   which is true and is what it said before anyone declared anything.
+ */
+export function compileEndpoint(declaration) {
+	const path = declaration?.path;
+	// Rule 2. A path that does not start with exactly one slash is either
+	// relative — meaning it would resolve against the origin's own path, which
+	// is not what anyone writing this means — or protocol-relative, which is a
+	// different host wearing a path's clothes.
+	if (typeof path !== "string" || !path.startsWith("/") || path.startsWith("//")) return undefined;
+
+	const fields = declaration.fields ?? {};
+	const windows = Array.isArray(declaration.windows) ? declaration.windows : [];
+	const raw = declaration.raw === true;
+
+	return {
+		label: typeof declaration.displayName === "string" && declaration.displayName !== "" ? declaration.displayName : "Declared",
+		// Marks the card, because these numbers came out of paths the user
+		// wrote. A wrong path is a configuration mistake, and the interface has
+		// to make that distinguishable from the plugin getting it wrong.
+		declared: true,
+		async read({ origin, get }) {
+			const url = new URL(path, origin);
+			// Rule 1, enforced again after construction rather than trusted. If
+			// these ever disagree, the request does not happen.
+			if (url.origin !== new URL(origin).origin) throw Object.assign(new Error("cross-origin-path"), { kind: "declaration" });
+
+			const body = await get(url.href, { raw, sameOrigin: url.origin, maxBytes: 1_000_000 });
+
+			const amount = {};
+			for (const key of AMOUNT_FIELDS) {
+				const value = toNumber(readPath(body, fields[key]));
+				if (value !== undefined) amount[key] = value;
+			}
+			const currency = readPath(body, fields.currency);
+			const plan = readPath(body, fields.plan);
+
+			return {
+				...amount,
+				...(typeof currency === "string" && currency !== "" ? { currency } : {}),
+				...(typeof plan === "string" && plan !== "" ? { plan } : {}),
+				isAvailable: amount.total === undefined ? undefined : amount.total > 0,
+				windows: windows.map((window) => resolveWindow(window, body)),
+				// Nothing resolved is worth saying out loud: it means every path
+				// in the declaration missed, which is a typo, not an empty
+				// account. Without this the card is indistinguishable from a
+				// vendor that simply reports nothing.
+				...(Object.keys(amount).length === 0 && windows.length === 0 ? { reason: "the declaration named no fields" } : {})
+			};
+		}
+	};
+}
+
+/** One declared window: `kind` and `minutes` are values, the rest are paths. */
+function resolveWindow(declaration, body) {
+	const resolved = { kind: declaration?.kind };
+	const minutes = toNumber(declaration?.minutes);
+	if (minutes !== undefined) resolved.minutes = minutes;
+	for (const key of WINDOW_PATHS) {
+		const value = readPath(body, declaration?.[key]);
+		if (value !== undefined) resolved[key] = value;
+	}
+	return resolved;
+}
+
+/**
+ * Index the user's declarations by origin.
+ *
+ * Normalized through the same function site attribution uses, so a declaration
+ * written `https://Relay.Example.com/v1/` matches an account discovered as
+ * `https://relay.example.com`. Without that the feature would appear not to
+ * work for reasons nobody could see.
+ */
+export function indexEndpoints(list) {
+	const byOrigin = new Map();
+	if (!Array.isArray(list)) return byOrigin;
+	for (const declaration of list) {
+		const origin = normalizeOrigin(declaration?.origin);
+		// First wins, so a duplicate is inert rather than quietly overriding.
+		if (origin !== undefined && !byOrigin.has(origin)) byOrigin.set(origin, declaration);
+	}
+	return byOrigin;
+}

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -759,7 +759,13 @@ export function apply(ctx, userConfig = {}) {
 				// A lazily detected relay program is remembered, so the probe
 				// happens once per site rather than once per balance read.
 				learnSoftware: fingerprints.learn,
-				detect
+				detect,
+				// Read through `config` rather than captured once, so editing a
+				// declaration takes effect on the next read instead of at the
+				// next restart — the whole point of registering the namespace.
+				get endpoints() {
+					return config.endpoints;
+				}
 			}),
 			logger
 		});

--- a/src/settings-schema.js
+++ b/src/settings-schema.js
@@ -43,7 +43,44 @@ export function buildSchema(z) {
 		})
 	]);
 
+	// One declared window. `kind` and `minutes` are values; every other field is
+	// a dotted PATH into the response body. The split is deliberate: a window's
+	// name and length are facts about the plan, and everything else is a
+	// location in a document only the user has seen.
+	const declaredWindow = z.object({
+		kind: z.string(),
+		minutes: z.number(),
+		usedPercent: z.string(),
+		usedRatio: z.string(),
+		remainingPercent: z.string(),
+		used: z.string(),
+		limit: z.string(),
+		resetsAt: z.string(),
+		resetInSeconds: z.string()
+	});
+
+	// A balance endpoint for a vendor with no built-in reader. See
+	// `declarative.js` for the boundary this runs inside — in particular, the
+	// request goes to the matching ACCOUNT's origin, and `origin` here is only
+	// the key used to find that account.
+	const declaredEndpoint = z.object({
+		origin: z.string(),
+		displayName: z.string(),
+		path: z.string(),
+		/** Send the key without the `Bearer` prefix, as some console APIs want. */
+		raw: z.boolean().default(false),
+		/** Dotted paths for `total`, `granted`, `used`, `currency`, `plan`. */
+		fields: z.dict(z.string()),
+		windows: z.array(declaredWindow)
+	});
+
 	return z.object({
+		/**
+		 * Balance or quota endpoints declared by the user, for vendors the built-in
+		 * table does not cover. Consulted only where nothing else could answer, so
+		 * an entry can add a vendor and can never change how a known one is read.
+		 */
+		endpoints: z.array(declaredEndpoint),
 		/**
 		 * Relay overrides, keyed by DSH provider route. Normally empty: sites are
 		 * discovered from the host's own provider configuration. An entry here is

--- a/test/declarative.test.js
+++ b/test/declarative.test.js
@@ -1,0 +1,297 @@
+/**
+ * Endpoints a user declares.
+ *
+ * This feature lets a configuration file decide where a request carrying the
+ * user's API key is sent. Every boundary in `declarative.js` therefore has a
+ * test here that tries to get through it, because a boundary nobody attacks is
+ * a boundary nobody has checked.
+ */
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { createBalanceReader, readBalance } from "../src/balance.js";
+import { compileEndpoint, indexEndpoints, readPath } from "../src/declarative.js";
+
+const ORIGIN = "https://relay-one.example";
+
+/** A declaration covering both halves of the card. */
+const DECLARATION = {
+	origin: ORIGIN,
+	displayName: "我的中转站",
+	path: "/api/quota",
+	fields: { total: "data.balance", granted: "data.total", used: "data.used", currency: "data.unit", plan: "data.plan_name" },
+	windows: [{ kind: "weekly", minutes: 10080, usedPercent: "data.week.percent", resetsAt: "data.week.reset_at" }]
+};
+
+const BODY = {
+	data: {
+		balance: "12.5",
+		total: 20,
+		used: 7.5,
+		unit: "CNY",
+		plan_name: "包月",
+		week: { percent: 63, reset_at: "2026-08-21T00:00:00Z" }
+	}
+};
+
+/** A `ctx` whose one provider route points at ORIGIN. */
+const ctxWith = (profile = { baseURL: `${ORIGIN}/v1`, apiKeyEnv: "RELAY_KEY" }) => ({
+	get: (name) =>
+		name === "llm"
+			? { listConfigurableProviders: () => [{ provider: "mine", settingsNs: "ns", settingsPath: [] }] }
+			: name === "credentials"
+				? { resolve: async () => ({ value: "sk-route-key" }) }
+				: { get: () => profile }
+});
+
+/** Record every request, and answer the declared path with `body`. */
+function spy(body, over = {}) {
+	const seen = [];
+	const fetch = async (url, init) => {
+		seen.push({ url, ...init });
+		return { ok: true, status: 200, json: async () => body, text: async () => JSON.stringify(body), ...over };
+	};
+	return { fetch, seen };
+}
+
+// --- it works at all ------------------------------------------------------------
+
+test("a declaration renders a full card from paths the user wrote", async () => {
+	const { fetch } = spy(BODY);
+	const result = await createBalanceReader(ctxWith(), { endpoints: [DECLARATION], fetch })();
+	assert.equal(result.fetched, true);
+	assert.equal(result.declared, true, "the card has to be able to say where these numbers came from");
+	assert.equal(result.total, 12.5, "a number sent as a string is still a number");
+	assert.equal(result.granted, 20);
+	assert.equal(result.used, 7.5);
+	assert.equal(result.currency, "CNY");
+	assert.equal(result.plan, "包月");
+	assert.deepEqual(result.windows, [{ kind: "weekly", minutes: 10080, usedPercent: 63, resetsAt: "2026-08-21T00:00:00.000Z" }]);
+});
+
+test("a path that misses costs that field and nothing else", async () => {
+	const { fetch } = spy(BODY);
+	const typo = { ...DECLARATION, fields: { ...DECLARATION.fields, total: "data.blance" } };
+	const result = await createBalanceReader(ctxWith(), { endpoints: [typo], fetch })();
+	assert.equal(result.fetched, true);
+	assert.equal(result.total, undefined);
+	assert.equal(result.granted, 20, "the fields that did resolve still render");
+});
+
+test("a declaration that resolves nothing says so rather than showing an empty account", async () => {
+	const { fetch } = spy({ unrelated: true });
+	const result = await createBalanceReader(ctxWith(), { endpoints: [{ origin: ORIGIN, path: "/x" }], fetch })();
+	assert.match(result.reason, /named no fields/);
+});
+
+test("an origin match is case- and trailing-slash-insensitive", async () => {
+	// Otherwise the feature appears not to work, for a reason nobody can see.
+	const { fetch } = spy(BODY);
+	const declared = { ...DECLARATION, origin: "https://Relay-One.Example/v1/" };
+	const result = await createBalanceReader(ctxWith(), { endpoints: [declared], fetch })();
+	assert.equal(result.declared, true);
+});
+
+// --- boundary 1: the request goes to the ACCOUNT's origin ------------------------
+
+test("a declaration cannot name a host the harness was not already talking to", async () => {
+	// The declared origin is a lookup key, nothing more. One that matches no
+	// configured provider is never consulted, so it can never cause a request.
+	const { fetch, seen } = spy(BODY);
+	const elsewhere = { ...DECLARATION, origin: "https://collector.example" };
+	const result = await createBalanceReader(ctxWith(), { endpoints: [elsewhere], fetch })();
+	assert.equal(result.supported, false);
+	assert.equal(result.reason, "unknown-software");
+	assert.equal(seen.length, 0, "no request may be made to an origin nobody configured");
+});
+
+test("the URL is built from the account's origin, not from the declaration's", async () => {
+	const { fetch, seen } = spy(BODY);
+	await createBalanceReader(ctxWith(), { endpoints: [DECLARATION], fetch })();
+	assert.equal(seen[0].url, `${ORIGIN}/api/quota`);
+});
+
+// --- boundary 2: the path cannot be a host in disguise ---------------------------
+
+test("a protocol-relative path is refused, because it is another host wearing a path", async () => {
+	// `new URL("//evil.example/x", "https://relay.example")` resolves to
+	// https://evil.example/x. The single most likely way to smuggle a host in.
+	assert.equal(compileEndpoint({ ...DECLARATION, path: "//collector.example/steal" }), undefined);
+	assert.equal(compileEndpoint({ ...DECLARATION, path: "https://collector.example/steal" }), undefined);
+	assert.equal(compileEndpoint({ ...DECLARATION, path: "api/quota" }), undefined, "a relative path is not what anyone means");
+	assert.equal(compileEndpoint({ ...DECLARATION, path: "" }), undefined);
+	assert.equal(compileEndpoint({ ...DECLARATION, path: undefined }), undefined);
+	assert.notEqual(compileEndpoint(DECLARATION), undefined);
+});
+
+test("a refused declaration leaves the account unsupported and sends nothing", async () => {
+	const { fetch, seen } = spy(BODY);
+	const smuggled = { ...DECLARATION, path: "//collector.example/steal" };
+	const result = await createBalanceReader(ctxWith(), { endpoints: [smuggled], fetch })();
+	assert.equal(result.supported, false);
+	assert.equal(seen.length, 0);
+});
+
+// --- boundary 3: only GET, and only our own headers ------------------------------
+
+test("nothing in a declaration reaches the request but the path", async () => {
+	const { fetch, seen } = spy(BODY);
+	const loaded = { ...DECLARATION, method: "POST", body: "x", headers: { "x-exfil": "1" } };
+	await createBalanceReader(ctxWith(), { endpoints: [loaded], fetch })();
+	assert.equal(seen[0].method, undefined, "no method is ever set, so it is a GET");
+	assert.equal(seen[0].body, undefined);
+	assert.deepEqual(Object.keys(seen[0].headers).sort(), ["accept", "authorization"]);
+});
+
+// --- boundary 4: the credential is the route's own -------------------------------
+
+test("the key comes from the route, and a declaration cannot name another one", async () => {
+	const { fetch, seen } = spy(BODY);
+	const greedy = { ...DECLARATION, apiKeyEnv: "SOMEONE_ELSES_KEY", credential: "SOMEONE_ELSES_KEY" };
+	await createBalanceReader(ctxWith(), { endpoints: [greedy], fetch })();
+	assert.equal(seen[0].headers.authorization, "Bearer sk-route-key");
+});
+
+test("the raw-key form is the only auth choice a declaration gets", async () => {
+	const { fetch, seen } = spy(BODY);
+	await createBalanceReader(ctxWith(), { endpoints: [{ ...DECLARATION, raw: true }], fetch })();
+	assert.equal(seen[0].headers.authorization, "sk-route-key");
+});
+
+test("a route with no key makes no request", async () => {
+	const { fetch, seen } = spy(BODY);
+	const ctx = ctxWith({ baseURL: `${ORIGIN}/v1` });
+	const result = await createBalanceReader(ctx, { endpoints: [DECLARATION], fetch })();
+	assert.equal(result.reason, "no-credential");
+	assert.equal(seen.length, 0);
+});
+
+// --- boundary 5: redirects stay on the origin ------------------------------------
+
+test("a cross-origin redirect fails instead of handing the key over", async () => {
+	// The default `follow` re-sends the Authorization header to wherever the
+	// redirect points, which is the cheapest possible way around boundary 1.
+	const fetch = async () => ({
+		ok: false,
+		status: 302,
+		headers: { get: (name) => (name === "location" ? "https://collector.example/x" : null) }
+	});
+	const result = await createBalanceReader(ctxWith(), { endpoints: [DECLARATION], fetch })();
+	assert.equal(result.fetched, false);
+	assert.equal(result.reason, "cross-origin-redirect");
+});
+
+test("a same-origin redirect is followed, once the origin has been checked", async () => {
+	let hop = 0;
+	const fetch = async (url, init) => {
+		hop += 1;
+		if (hop === 1) {
+			assert.equal(init.redirect, "manual", "the hops have to be taken by hand to be checked at all");
+			return { ok: false, status: 301, headers: { get: () => `${ORIGIN}/api/quota/` } };
+		}
+		assert.equal(url, `${ORIGIN}/api/quota/`);
+		return { ok: true, status: 200, json: async () => BODY, text: async () => JSON.stringify(BODY) };
+	};
+	const result = await createBalanceReader(ctxWith(), { endpoints: [DECLARATION], fetch })();
+	assert.equal(result.total, 12.5);
+});
+
+test("a same-origin redirect loop ends rather than spinning", async () => {
+	const fetch = async () => ({ ok: false, status: 302, headers: { get: () => `${ORIGIN}/api/quota` } });
+	const result = await createBalanceReader(ctxWith(), { endpoints: [DECLARATION], fetch })();
+	assert.equal(result.reason, "http-302");
+});
+
+// --- boundary 6: bounded body ----------------------------------------------------
+
+test("an oversized body is refused before it is parsed", async () => {
+	const huge = `{"data":{"balance":"${"9".repeat(2_000_000)}"}}`;
+	const fetch = async () => ({ ok: true, status: 200, text: async () => huge });
+	const result = await createBalanceReader(ctxWith(), { endpoints: [DECLARATION], fetch })();
+	assert.equal(result.reason, "too-large");
+});
+
+test("a streaming body is cut off at the cap rather than buffered whole", async () => {
+	// The length check bounds the parse; only the reader bounds the download.
+	let cancelled = false;
+	const chunk = new Uint8Array(300_000);
+	const fetch = async () => ({
+		ok: true,
+		status: 200,
+		body: {
+			getReader: () => ({
+				read: async () => ({ done: false, value: chunk }),
+				cancel: async () => {
+					cancelled = true;
+				}
+			})
+		}
+	});
+	const result = await createBalanceReader(ctxWith(), { endpoints: [DECLARATION], fetch })();
+	assert.equal(result.reason, "too-large");
+	assert.equal(cancelled, true, "an endpoint that keeps talking must be hung up on");
+});
+
+test("the cap applies only where a declaration asked for one", async () => {
+	// Built-in schemes are unchanged: they call `get` without a byte budget and
+	// keep taking the fast `response.json()` path.
+	const { fetch } = spy({ is_available: true, balance_infos: [{ currency: "CNY", total_balance: "3" }] });
+	const result = await readBalance({ scheme: "deepseek", origin: "https://api.deepseek.com", apiKey: "k", fetch });
+	assert.equal(result.total, 3);
+});
+
+// --- boundary 7: paths cannot climb out ------------------------------------------
+
+test("a path cannot reach the prototype chain", async () => {
+	const body = { data: { balance: 1 } };
+	for (const path of ["__proto__", "constructor", "data.__proto__.polluted", "data.constructor.name"]) {
+		assert.equal(readPath(body, path), undefined, path);
+	}
+	assert.equal(readPath(body, "data.balance"), 1);
+});
+
+test("a path that walks off the end of the document is absent, not an error", async () => {
+	const body = { a: { b: [1, 2] } };
+	assert.equal(readPath(body, "a.b.5"), undefined);
+	assert.equal(readPath(body, "a.b.0.c.d.e"), undefined);
+	assert.equal(readPath(body, "a.b.1"), 2, "indexing an array is fine, and useful");
+	assert.equal(readPath(body, ""), undefined);
+	assert.equal(readPath(body, undefined), undefined);
+});
+
+// --- boundary 8: a declaration cannot shadow a built-in --------------------------
+
+test("declaring an endpoint on a known vendor's origin changes nothing", async () => {
+	// Otherwise this is a way to make the panel read DeepSeek however anyone
+	// with write access to a settings file likes.
+	const { fetch, seen } = spy({ is_available: true, balance_infos: [{ currency: "CNY", total_balance: "3.00" }] });
+	const ctx = {
+		get: (name) =>
+			name === "llm"
+				? { listConfigurableProviders: () => [{ provider: "ds", settingsNs: "ns", settingsPath: [] }] }
+				: name === "credentials"
+					? { resolve: async () => ({ value: "sk-route-key" }) }
+					: { get: () => ({ baseURL: "https://api.deepseek.com", apiKeyEnv: "K" }) }
+	};
+	const hijack = { origin: "https://api.deepseek.com", path: "/somewhere/else", fields: { total: "x" } };
+	const result = await createBalanceReader(ctx, { endpoints: [hijack], fetch })();
+	assert.equal(result.declared, undefined);
+	assert.equal(result.total, 3);
+	assert.equal(new URL(seen[0].url).pathname, "/user/balance", "the built-in reader decided the path");
+});
+
+// --- the index -------------------------------------------------------------------
+
+test("a duplicate declaration is inert, not an override", async () => {
+	const first = { origin: ORIGIN, path: "/a" };
+	const second = { origin: `${ORIGIN}/`, path: "/b" };
+	assert.equal(indexEndpoints([first, second]).get(ORIGIN).path, "/a");
+});
+
+test("a malformed endpoints list is empty, not a crash", async () => {
+	for (const junk of [undefined, null, "endpoints", 5, [null], [{}], [{ origin: "not a url" }]]) {
+		assert.equal(indexEndpoints(junk).size === 0 || indexEndpoints(junk).size === 1, true, JSON.stringify(junk));
+	}
+	assert.equal(indexEndpoints([{ origin: "not a url" }]).size, 0);
+});


### PR DESCRIPTION
Closes #14。依赖 #11 的窗口模型。

## 加了什么

新模块 `src/declarative.js`。用户在 `settings.yaml` 里声明一个端点，面板就能读它：

```yaml
tokenledger:
  endpoints:
    - origin: https://relay.example.com
      displayName: 我的中转站
      path: /api/quota
      fields:
        total: data.balance
        currency: data.unit
      windows:
        - kind: weekly
          usedPercent: data.week.percent
          resetsAt: data.week.reset_at
```

`fields` / `windows` 里是**取值路径**——描述"数字在哪儿"，不描述"怎么取"。没有表达式语言，没有任何东西被求值，唯一的操作是"往下走一层"。

## 边界才是这个 PR 的主体

这个功能等于让配置文件决定"往哪儿发一个带着用户密钥的请求"。这一点没法靠"提醒用户小心"来缓解，所以七条边界全部写死在代码里，而且**每一条都有一个试图突破它的测试**——没人攻击过的边界等于没人检查过。

| 边界 | 怎么实现的 | 试图突破它的测试 |
| --- | --- | --- |
| 1. 请求只发往**账户的** origin | 声明里的 `origin` 只当查找键，用来匹配用户已配置的 provider；URL 用账户的 origin 构造 | 声明一个没配过的 origin → 完全不产生请求 |
| 2. `path` 只能是单斜杠绝对路径 | `//host/x` 是协议相对 URL，`new URL()` 会把它解析到别的主机；构造完再校验一次 origin | `//collector.example/steal`、`https://...`、相对路径全部被拒 |
| 3. 只发 GET | 声明里的 method / body / headers 一律不读 | 塞了 `method`/`body`/`headers` 的声明 → 请求上只有 `accept` 和 `authorization` |
| 4. 密钥只来自那条路由自己的 `apiKeyEnv` | 走既有的 credentials seam，声明不能指定凭据 | 声明里塞 `apiKeyEnv`/`credential` → 用的仍是路由的 key |
| 5. 跨源重定向失败，不跟随 | `redirect: "manual"`，逐跳检查 origin | 302 到别的主机 → `cross-origin-redirect`，同源 301 → 正常跟随，同源死循环 → 3 跳后停 |
| 6. 响应体有上限和超时 | 有 `getReader` 就流式读并在超限时 `cancel()`，没有就退回长度检查 | 2MB 响应 → `too-large`；流式的会被**挂断**（断言 `cancel` 被调用） |
| 7. 不能覆盖内置读法 | 只在内置表答不上来时才轮到它 | 对着 `api.deepseek.com` 声明一个端点 → 内置 reader 照常，路径仍是 `/user/balance` |

另外取值路径不能爬到原型链上（`__proto__` / `constructor` / `prototype` 被挡），走出文档边界返回缺席而不是报错。

## 第 5 条对所有 scheme 都生效了

默认的 `redirect: "follow"` 会把 Authorization 头**重新发到重定向指向的任何地方**。一个中转站回一句 `302 https://collector.example/`，用户的 key 就送过去了——这是绕过第 1 条最省事的办法，也和 New API reader 里那句"重定向会丢掉 Authorization 头"的注释是同一个问题的两面。

所以改在 `get()` 上，内置 scheme 一起受益。同源重定向照常跟随（New API 那个 `/api/usage/token/` 的 301 现在也能正确处理），跨源直接失败。

字节上限只在声明式路径上生效——内置 scheme 不传 `maxBytes`，仍走 `response.json()` 快路径，有测试守。

## 界面

这类卡片标注「自定义端点」/「declared endpoint」。数字是用户自己配的路径取出来的，**取错了是配置问题不是插件问题**，界面得让这一点看得出来——否则第一份 bug report 会开到我们头上。

另外，所有路径都没匹配上时，卡片会说"这份声明没取到任何字段"，而不是留一张看起来像"账户是空的"的空卡。

## 测试

`test/declarative.test.js` 23 个，总计 **355 全绿**。
