### PR TITLE
fix: inject 必须是数组，否则宿主起不来

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,24 +1,59 @@
 {
   "name": "dsh-tokenledger",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dsh-tokenledger",
-      "version": "0.0.1",
+      "version": "0.1.0",
       "license": "MIT",
-      "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1"
+      "devDependencies": {
+        "@deepseek-ai/cordis": "^4.0.1"
       },
       "engines": {
         "node": ">=22"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/schemastery": "^3.18.1"
+      },
+      "peerDependenciesMeta": {
+        "@deepseek-ai/schemastery": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@deepseek-ai/cordis": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/cordis/-/cordis-4.0.1.tgz",
+      "integrity": "sha512-YBdskTU2Po1kru3GgcUWUbkTsPMA9LkSQDAY8rBkFJeajdgcQad3QPJZE26JyK99Xb6HaASvoXg2DSUTeN/0Nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/cosmokit": "^1.8.2",
+        "@standard-schema/spec": "^1.1.0"
+      },
+      "bin": {
+        "cordis": "bin.js"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis-plugin-include": "^1.0.6",
+        "@deepseek-ai/cordis-plugin-loader": "^1.0.2"
+      },
+      "peerDependenciesMeta": {
+        "@deepseek-ai/cordis-plugin-include": {
+          "optional": true
+        },
+        "@deepseek-ai/cordis-plugin-loader": {
+          "optional": true
+        }
       }
     },
     "node_modules/@deepseek-ai/cosmokit": {
       "version": "1.8.2",
       "resolved": "https://registry.npmjs.org/@deepseek-ai/cosmokit/-/cosmokit-1.8.2.tgz",
       "integrity": "sha512-muBOKtSrUKU5m/xpq8ZXWL6hQ/jgd4PhU2PqH97bcxIiLEJfNwZOGQEx4t/aS/GgxRAR+ra9pMHPMtTHU4sqqA==",
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@deepseek-ai/schemastery": {
@@ -26,6 +61,8 @@
       "resolved": "https://registry.npmjs.org/@deepseek-ai/schemastery/-/schemastery-3.18.1.tgz",
       "integrity": "sha512-Qn0FCSwCQnpnj6SB31I6i2sIKgKWnkbJM8O0EU91Gv2UsYVvtZTl6IA0sCwk2e2MZf5S8w5hpq9QkeVvK9qwxg==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@deepseek-ai/cosmokit": "^1.8.2",
         "@standard-schema/spec": "^1.1.0"
@@ -35,6 +72,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "devOptional": true,
       "license": "MIT"
     }
   }

--- a/package.json
+++ b/package.json
@@ -71,5 +71,8 @@
     "@deepseek-ai/schemastery": {
       "optional": true
     }
+  },
+  "devDependencies": {
+    "@deepseek-ai/cordis": "^4.0.1"
   }
 }

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -69,13 +69,24 @@ export const name = "tokenledger";
  * forever. The optional-capability idiom in this codebase is `ctx.get(name)`,
  * which returns the service or undefined without registering a dependency.
  */
-export const inject = {
-	required: ["sessionPersistence"],
-	// `workspace` only supplies display names for project directories. A
-	// composition without it still gets the whole per-project breakdown, named
-	// by directory, so requiring it would trade a real capability for a label.
-	optional: ["workspace"]
-};
+/**
+ * Services this plugin cannot start without.
+ *
+ * **An array, never an object.** Cordis reads an object `inject` as a
+ * `name -> intercept config` map, not as `{ required, optional }` — every key
+ * becomes a REQUIRED service name. Declaring the latter asked for two services
+ * called `required` and `optional`, neither of which exists, so the plugin sat
+ * pending forever and DSH's activation assertion took the whole host down with
+ * it. `dsh web` did not start.
+ *
+ * This version of Cordis has no notion of an optional dependency at all:
+ * `Inject.resolve` puts every declared name in one table with no strength
+ * attached. Something a plugin can work without is therefore NOT declared here
+ * — it is read with `ctx.get(name)`, which returns `undefined` when the service
+ * is absent rather than throwing. `workspace` is read that way, per sweep, so a
+ * service that mounts later is picked up on its own.
+ */
+export const inject = ["sessionPersistence"];
 
 /** Defaults chosen so an unconfigured mount still does something useful. */
 const DEFAULTS = {

--- a/test/boot.test.js
+++ b/test/boot.test.js
@@ -1,0 +1,89 @@
+/**
+ * Does the plugin actually activate.
+ *
+ * Every other test in this repository passed while `dsh web` refused to start.
+ * They had to: the bug was a wrong `inject` shape, and the static assertion
+ * guarding `inject` was written in the same commit, so it asserted whatever the
+ * code happened to say. A test authored beside the code it checks cannot catch
+ * a mistake in the author's model of the contract.
+ *
+ * So this one does not assert a shape. It boots the plugin against the real
+ * Cordis, with the same service missing that a real composition might be
+ * missing, and asks the only question that matters: did the fiber reach ACTIVE.
+ *
+ * `@deepseek-ai/cordis` is a devDependency for this. Nothing ships with it —
+ * the package still installs with zero runtime dependencies, which
+ * `packaging.test.js` enforces separately.
+ */
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { Context } from "@deepseek-ai/cordis";
+
+import * as plugin from "../src/plugin.js";
+
+/** Cordis fiber states; 2 is ACTIVE and 0 is PENDING on a missing service. */
+const ACTIVE = 2;
+
+/** Enough of `sessionPersistence` for a sweep to run and find nothing. */
+const persistence = { listSnapshots: async () => [], readFrom: async () => ({ events: [] }) };
+
+/** Boot `subject` in a fresh context and return its fiber once it settles. */
+async function boot(subject, provide = { sessionPersistence: persistence }) {
+	const ctx = new Context();
+	for (const [name, value] of Object.entries(provide)) ctx.reflect.provide(name, value);
+	const fiber = ctx.plugin(subject, { database: ":memory:", sweepIntervalMs: 0, sweepOnStart: false });
+	await fiber.await?.();
+	return { ctx, fiber };
+}
+
+test("the plugin activates with only the service it declares", async () => {
+	// `workspace` is deliberately absent. It supplies project display names and
+	// nothing else, so a composition without it must still boot — and this
+	// Cordis has no optional dependency, so the only way to depend on it
+	// weakly is not to declare it.
+	const { ctx, fiber } = await boot(plugin);
+	try {
+		assert.equal(fiber.state, ACTIVE, `fiber is in state ${fiber.state}, not ACTIVE — it is waiting for a service`);
+	} finally {
+		await ctx.fiber?.dispose?.();
+	}
+});
+
+test("a required/optional inject object would NOT activate, which is why it is banned", async () => {
+	// The shape that shipped and took the host down. Kept as an executable
+	// record of what Cordis does with it: `Inject.resolve` reads an object as a
+	// `name -> intercept config` map, so this asks for two services literally
+	// named `required` and `optional`.
+	//
+	// This is also what proves the test above can fail. A boot check that
+	// passes for both shapes would be checking nothing.
+	const broken = { name: plugin.name, apply: plugin.apply, inject: { required: ["sessionPersistence"], optional: ["workspace"] } };
+	const { ctx, fiber } = await boot(broken);
+	try {
+		assert.notEqual(fiber.state, ACTIVE, "if this ever activates, Cordis changed and the rule above can be revisited");
+	} finally {
+		await ctx.fiber?.dispose?.();
+	}
+});
+
+test("the plugin does not activate when its one real dependency is missing", async () => {
+	// The other half of the same question: `sessionPersistence` is genuinely
+	// required, and declaring it has to mean something.
+	const { ctx, fiber } = await boot(plugin, {});
+	try {
+		assert.notEqual(fiber.state, ACTIVE);
+	} finally {
+		await ctx.fiber?.dispose?.();
+	}
+});
+
+test("providing workspace changes nothing about whether it boots", async () => {
+	const { ctx, fiber } = await boot(plugin, { sessionPersistence: persistence, workspace: { resolveByPath: async () => undefined } });
+	try {
+		assert.equal(fiber.state, ACTIVE);
+	} finally {
+		await ctx.fiber?.dispose?.();
+	}
+});

--- a/test/packaging.test.js
+++ b/test/packaging.test.js
@@ -39,6 +39,39 @@ test("the resolve the scanner performs actually succeeds", () => {
 	}
 });
 
+test("inject is a flat array of names, because an object means something else", async () => {
+	// Cordis normalizes an object `inject` as a `name -> intercept config` map:
+	//
+	//   if (Array.isArray(inject)) for (const name of inject) result[name] = null;
+	//   else for (const name of Object.keys(inject)) result[name] = inject[name] ?? null;
+	//
+	// So `{ required: [...], optional: [...] }` does not mean what it reads like.
+	// It asks for two services named `required` and `optional`. Neither exists,
+	// the plugin stays pending, and DSH's activation assertion fails the whole
+	// boot — `dsh web` did not start at all. That shipped once.
+	//
+	// The test that should have caught it was widened in the same commit to
+	// accept the object, which is worse than having no test: it reported the bug
+	// as verified.
+	const { inject } = await import("../src/plugin.js");
+	assert.ok(Array.isArray(inject), "an object inject is a config map, not a required/optional split");
+	for (const name of inject) assert.equal(typeof name, "string", `${String(name)} must be a bare service name`);
+});
+
+test("only services the plugin genuinely cannot start without are injected", async () => {
+	// This Cordis has no optional dependency: every declared name is required,
+	// and a missing one takes the host down rather than degrading a feature.
+	// Anything the plugin can work without is read with `ctx.get(name)`, which
+	// answers `undefined` instead of throwing — `workspace` is read that way,
+	// so a per-project row falls back to its directory name and nothing breaks.
+	const { inject } = await import("../src/plugin.js");
+	assert.deepEqual(inject, ["sessionPersistence"]);
+	assert.equal(inject.includes("workspace"), false, "titles are a nicety; requiring them would trade the panel for a label");
+
+	const source = readFileSync(new URL("../src/plugin.js", import.meta.url), "utf8");
+	assert.match(source, /ctx\.get\?\.\("workspace"\)/, "and it has to actually be read through the tolerant door");
+});
+
 test("declaring dsh.client obliges the package to export ./client", () => {
 	// The scanner throws on this mismatch rather than skipping the package.
 	if (pkg.dsh?.client === undefined) return;
@@ -50,10 +83,7 @@ const root = await import("../src/index.js");
 
 test("the package root is a valid Cordis plugin, because the entry name points at it", async () => {
 	assert.equal(typeof root.apply, "function", "a bare entry name loads the root export as the plugin");
-	// Cordis accepts either an array or `{ required, optional }`. The object
-	// form is what lets a service supply a nicety — project display names —
-	// without its absence withholding the capability underneath.
-	assert.ok(Array.isArray(root.inject) || Array.isArray(root.inject?.required));
+	assert.ok(Array.isArray(root.inject));
 	assert.equal(typeof root.name, "string");
 });
 


### PR DESCRIPTION
Closes #24。**这是我在 #22 里引入的,导致宿主起不来,不是面板不显示。**

## 根因

#22 把 `inject` 从数组改成对象,以为那是 Cordis 的"必需/可选"写法:

```js
export const inject = {
	required: ["sessionPersistence"],
	optional: ["workspace"]
};
```

`@deepseek-ai/cordis@4.0.1` 不是这么读的:

```js
function resolve(inject, result = Object.create(null)) {
	if (!inject) return result;
	if (Array.isArray(inject)) for (const name of inject) result[name] = null;
	else if (Reflect.has(inject, symbols.checkProto)) { ... }
	else for (const name of Object.keys(inject)) result[name] = inject[name] ?? null;
	return result;
}
```

对象走最后一条:**键是服务名,值是 intercept 配置**。它自己的注释也写着 "required services, as an array or a **name → config map**"。

所以我们声明的是"**必需两个分别叫 `required` 和 `optional` 的服务**"。报错信息里那两个名字就是原样回显:

```
dsh-tokenledger: pending (waiting for services: required, optional)
```

## 这个版本没有"可选依赖"

`Inject.resolve` 把所有名字填进同一张表,不带强弱。想"有就用、没有也行",唯一的路是**不声明,用 `ctx.get(name)` 取**——服务不在返回 `undefined`,不抛。

而我们**本来就是这么写的**:`refreshProjectTitles` 里是 `ctx.get?.("workspace")`。那个 `optional` 声明从头到尾没起过作用,只带来了这个 bug。改回数组即可,而且因为是每次扫描现取,后挂载的 workspace 服务会被自动捡起来。

## 为什么测试没拦住——这部分比 bug 本身严重

`test/packaging.test.js` 里守 `inject` 的那条断言,是**在同一个 commit 里被我放宽的**:

```js
assert.ok(Array.isArray(root.inject) || Array.isArray(root.inject?.required));
```

它没有验证契约,它验证了我当时的误解。**跟着被检查的代码一起写出来的静态断言,抓不到作者对契约的理解错误**——我会把断言写成刚好匹配我写的东西。这比没有测试更糟:它给出了"已验证"的假象。

## 所以新测试不断言形状

`test/boot.test.js` 拿**真的 Cordis** 把插件启起来,问唯一重要的那个问题:fiber 到没到 ACTIVE。

四条:

1. 只提供 `sessionPersistence`(**故意不给 `workspace`**)→ 必须 ACTIVE
2. 把 #22 那个坏形状照原样启一遍 → 必须**不** ACTIVE ——这条是用来证明第 1 条**能失败的**。两个形状都通过的启动检查等于什么都没查
3. 不给 `sessionPersistence` → 必须不 ACTIVE(声明它得有意义)
4. 给了 `workspace` → 照常 ACTIVE

`@deepseek-ai/cordis` 因此成为 **devDependency**。运行时依赖仍然是零个,`packaging.test.js` 里那条断言单独守着。

```
dependencies:    (none)
devDependencies: { '@deepseek-ai/cordis': '^4.0.1' }
peer:            { '@deepseek-ai/schemastery': '^3.18.1' }  // optional
```

## 验证

```
$ node --test test/boot.test.js
ok 1 - the plugin activates with only the service it declares
ok 2 - a required/optional inject object would NOT activate, which is why it is banned
ok 3 - the plugin does not activate when its one real dependency is missing
ok 4 - providing workspace changes nothing about whether it boots
```

全量 **385 全绿**。
