### PR TITLE
fix: 面板 404 的两个叠加原因——服务名 httpServer，以及一个被吞掉的 ReferenceError

### DIFF
--- a/src/http.js
+++ b/src/http.js
@@ -3,7 +3,7 @@
  *
  * ## Why this needs its own fence
  *
- * `webServer.register({ kind: 'exact' })` wins over the RPC prefix, which means
+ * `httpServer.register({ kind: 'exact' })` wins over the RPC prefix, which means
  * these routes sit **outside** the RPC trust boundary. Nothing upstream is
  * checking the caller for us, so the handler does it, and it does it on the
  * peer socket address rather than on the `Host` header: a header is whatever
@@ -210,26 +210,34 @@ export function usagePayload(deps, query) {
 /**
  * Register the read-only routes, if this composition has a web server.
  *
- * `webServer` is reached through `ctx.get` rather than declared in `inject`,
- * for the same reason `commands` and `settings` are: a headless composition
- * must still collect usage, and Cordis's `inject` has no optional form.
+ * `httpServer` is reached through a nested `inject` rather than the plugin's
+ * own, for the same reason `commands` and `settings` are sampled: a headless
+ * composition must still collect usage, and Cordis's `inject` has no optional
+ * form, so a required declaration would refuse to load without a browser.
  *
  * @returns whether the routes were registered.
  */
 export function registerRoutes(ctx, deps) {
-	// WAITED FOR, not sampled. `ctx.get` at mount time answers undefined for a
-	// service that mounts later, and on a real install `webServer` is one of
-	// them: the routes silently never registered and the panel got a 404 from a
-	// plugin whose host half had demonstrably loaded. This is the third time the
-	// same mistake has shipped — `settings` twice, now this — so the sampling
-	// form is not used for an optional service anywhere in this package.
+	// The service is `httpServer`. The PACKAGE is `dsh-host-webserver`, and
+	// naming the service after the package — `webServer` — is what shipped, so
+	// the nested fiber below waited on a name nothing provides and the routes
+	// were never registered. Upstream is unambiguous: `super(ctx, "httpServer")`.
+	//
+	// Nothing reported it. A nested `ctx.inject` is its own fiber, and DSH's
+	// activation assertion only covers top-level entries, so the host half
+	// "loaded" while the panel got a 404 from routes that did not exist.
+	//
+	// WAITED FOR, not sampled, for the separate reason recorded below: `ctx.get`
+	// at mount time answers undefined for a service that mounts later, which is
+	// how this same route silently vanished twice before. Name and lookup form
+	// are two independent ways to get this wrong and both have now been wrong.
 	if (typeof ctx.inject !== "function") {
-		const immediate = typeof ctx.get === "function" ? ctx.get("webServer") : undefined;
+		const immediate = typeof ctx.get === "function" ? ctx.get("httpServer") : undefined;
 		if (immediate === undefined || typeof immediate.register !== "function") return false;
 		return attachRoutes(ctx, immediate, deps);
 	}
-	ctx.inject(["webServer"], (scoped) => {
-		attachRoutes(scoped, scoped.webServer, deps);
+	ctx.inject(["httpServer"], (scoped) => {
+		attachRoutes(scoped, scoped.httpServer, deps);
 		deps.logger?.info?.("tokenledger: serving %s and %s", USAGE_PATH, BALANCE_PATH);
 	});
 	return true;
@@ -240,7 +248,7 @@ export function registerRoutes(ctx, deps) {
  *
  * @returns true, so the caller can report that a surface exists.
  */
-function attachRoutes(ctx, webServer, deps) {
+function attachRoutes(ctx, httpServer, deps) {
 	const logger = deps.logger;
 
 	const send = (res, status, value) => {
@@ -255,7 +263,7 @@ function attachRoutes(ctx, webServer, deps) {
 	const route = (path, build, label) => {
 		ctx.effect(
 			() =>
-				webServer.register({
+				httpServer.register({
 					kind: "exact",
 					path,
 					handler: async (req, res) => {

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -807,7 +807,14 @@ export function apply(ctx, userConfig = {}) {
 				// A lazily detected relay program is remembered, so the probe
 				// happens once per site rather than once per balance read.
 				learnSoftware: fingerprints.learn,
-				detect,
+				// `config.detect`, not a bare `detect`. Lifting the fingerprint
+				// registry out of apply() removed the local binding this used to
+				// close over, and the leftover reference threw a ReferenceError
+				// the moment `registerRoutes` was called — swallowed by the catch
+				// below into a warning nobody reads, so the HTTP routes silently
+				// stopped registering and the panel 404'd for every install after
+				// that refactor.
+				detect: config.detect,
 				// Read through `config` rather than captured once, so editing a
 				// declaration takes effect on the next read instead of at the
 				// next restart — the whole point of registering the namespace.
@@ -819,7 +826,12 @@ export function apply(ctx, userConfig = {}) {
 		});
 		if (!served) logger?.info?.("tokenledger: no web server in this composition; the panel will not be served");
 	} catch (error) {
-		logger?.warn?.("tokenledger: could not register the HTTP routes: %s", error?.message ?? error);
+		// At error level, with the stack. This catch exists so a broken panel
+		// never takes the harness down, and it did that job — but it also turned
+		// a ReferenceError in our own code into one grey line, and the routes
+		// were missing for weeks behind it. A caught bug still has to look like
+		// a bug.
+		logger?.error?.("tokenledger: could not register the HTTP routes: %s", error?.stack ?? error?.message ?? error);
 	}
 
 	if (config.sweepOnStart) void runSweep();

--- a/test/boot.test.js
+++ b/test/boot.test.js
@@ -35,6 +35,10 @@ async function boot(subject, provide = { sessionPersistence: persistence }) {
 	for (const [name, value] of Object.entries(provide)) ctx.reflect.provide(name, value);
 	const fiber = ctx.plugin(subject, { database: ":memory:", sweepIntervalMs: 0, sweepOnStart: false });
 	await fiber.await?.();
+	// A nested `ctx.inject` is a CHILD fiber, and awaiting the parent does not
+	// await it. The routes attach on that child, so a check that skips this
+	// settles too early and reports an empty route table for a healthy plugin.
+	await new Promise((resolve) => setTimeout(resolve, 50));
 	return { ctx, fiber };
 }
 
@@ -74,6 +78,113 @@ test("the plugin does not activate when its one real dependency is missing", asy
 	const { ctx, fiber } = await boot(plugin, {});
 	try {
 		assert.notEqual(fiber.state, ACTIVE);
+	} finally {
+		await ctx.fiber?.dispose?.();
+	}
+});
+
+// --- the routes actually attach ------------------------------------------------
+
+/** A stand-in for the host's HTTP server that records what gets registered. */
+function httpServerStub() {
+	const routes = [];
+	return { routes, register: (spec) => (routes.push(spec), () => {}), registerUpgrade: () => () => {}, registerFallback: () => () => {} };
+}
+
+test("the panel's routes register against the service the host actually provides", async () => {
+	// The service is `httpServer`. The PACKAGE is `dsh-host-webserver`, and the
+	// name that shipped was `webServer` — so the nested inject waited forever,
+	// the routes never existed, and the panel 404'd while every log line said
+	// the plugin had loaded.
+	//
+	// Nothing static could have caught it. `http.test.js` asserted the waited-for
+	// name and passed, because it asserted whatever the source said. Only asking
+	// "did a route appear on the real service" is a question the author's own
+	// wrong assumption cannot answer for itself.
+	const httpServer = httpServerStub();
+	const { ctx, fiber } = await boot(plugin, { sessionPersistence: persistence, httpServer });
+	try {
+		assert.equal(fiber.state, ACTIVE);
+		const paths = httpServer.routes.map((route) => route.path).sort();
+		assert.deepEqual(paths, ["/api/tokenledger/balance", "/api/tokenledger/usage"]);
+		for (const route of httpServer.routes) {
+			assert.equal(route.kind, "exact", "an exact route wins over the RPC prefix; a prefix route would not");
+			assert.equal(typeof route.handler, "function");
+		}
+	} finally {
+		await ctx.fiber?.dispose?.();
+	}
+});
+
+test("the usage route answers a real request end to end", async () => {
+	// Registration is only half of it. `apply()` wraps route setup in a catch so
+	// a broken panel never takes the harness down — which also meant a
+	// ReferenceError in our own code (`detect`, left behind by a refactor)
+	// became one grey warning while every request 404'd. Calling the handler is
+	// the only way to find the next one of those.
+	const httpServer = httpServerStub();
+	const { ctx } = await boot(plugin, { sessionPersistence: persistence, httpServer });
+	try {
+		const usage = httpServer.routes.find((route) => route.path === "/api/tokenledger/usage");
+		assert.ok(usage, "no usage route to call");
+
+		let status;
+		let body;
+		await usage.handler(
+			{ method: "GET", url: "/api/tokenledger/usage", socket: { remoteAddress: "127.0.0.1" }, headers: { host: "127.0.0.1:3080" } },
+			{ writeHead: (code) => void (status = code), end: (text) => void (body = JSON.parse(text)) }
+		);
+
+		assert.equal(status, 200, `handler answered ${status}: ${JSON.stringify(body)}`);
+		assert.equal(body.ok, true);
+		// The sections the panel renders. A payload missing one of these is a
+		// blank card, and a blank card is indistinguishable from an empty account.
+		for (const key of ["totals", "windows", "days", "models", "sites", "projects", "accounts", "diagnostics"]) {
+			assert.ok(key in body, `payload has no ${key}`);
+		}
+	} finally {
+		await ctx.fiber?.dispose?.();
+	}
+});
+
+test("a non-loopback caller is refused by the route, not served", async () => {
+	// The fence lives in the handler, so it has to survive being reached through
+	// a real registration rather than only through a direct unit call.
+	const httpServer = httpServerStub();
+	const { ctx } = await boot(plugin, { sessionPersistence: persistence, httpServer });
+	try {
+		const usage = httpServer.routes.find((route) => route.path === "/api/tokenledger/usage");
+		let status;
+		await usage.handler(
+			{ method: "GET", url: "/api/tokenledger/usage", socket: { remoteAddress: "203.0.113.7" }, headers: { host: "127.0.0.1:3080" } },
+			{ writeHead: (code) => void (status = code), end: () => {} }
+		);
+		assert.equal(status, 403);
+	} finally {
+		await ctx.fiber?.dispose?.();
+	}
+});
+
+test("a service under any other name registers nothing, which is the whole bug", async () => {
+	// Proves the test above can fail. Provided as `webServer`, the routes do not
+	// appear — and the plugin still activates, which is exactly why this went
+	// unnoticed: a nested inject fiber is not an entry, so DSH's activation
+	// assertion never sees it hanging.
+	const webServer = httpServerStub();
+	const { ctx, fiber } = await boot(plugin, { sessionPersistence: persistence, webServer });
+	try {
+		assert.equal(fiber.state, ACTIVE, "it boots perfectly happily, serving nothing");
+		assert.deepEqual(webServer.routes, []);
+	} finally {
+		await ctx.fiber?.dispose?.();
+	}
+});
+
+test("a headless composition still boots, just without the routes", async () => {
+	// No HTTP server at all. Collecting usage must not depend on a browser.
+	const { ctx, fiber } = await boot(plugin);
+	try {
+		assert.equal(fiber.state, ACTIVE);
 	} finally {
 		await ctx.fiber?.dispose?.();
 	}

--- a/test/http.test.js
+++ b/test/http.test.js
@@ -203,10 +203,16 @@ test("the balance route only exists when a reader was supplied", () => {
 });
 
 test("the web server is waited for, not sampled at mount", async () => {
-	// Third time this mistake shipped: ctx.get answers undefined for a service
-	// that mounts later, and webServer is one of them. The routes silently never
-	// registered, and the panel got a 404 from a plugin whose host half had
-	// demonstrably loaded — the SQLite store was open in the same log.
+	// ctx.get answers undefined for a service that mounts later, and the HTTP
+	// server is one of them. The routes silently never registered, and the panel
+	// got a 404 from a plugin whose host half had demonstrably loaded — the
+	// SQLite store was open in the same log.
+	//
+	// Note what this test could NOT catch: the name being wrong. It asserted
+	// whatever name the source used, so when that was `webServer` — the PACKAGE
+	// name, not the service name — this passed and the panel still 404'd. The
+	// question "is the name right" is only answerable by booting against the
+	// real thing, which `test/boot.test.js` now does.
 	const registered = [];
 	let waitedFor;
 	const ctx = {
@@ -215,14 +221,14 @@ test("the web server is waited for, not sampled at mount", async () => {
 		inject: (deps, run) => {
 			waitedFor = deps;
 			run({
-				webServer: { register: (spec) => void registered.push(spec) },
+				httpServer: { register: (spec) => void registered.push(spec) },
 				effect: (fn) => fn()
 			});
 		},
 		effect: (fn) => fn()
 	};
 	assert.equal(registerRoutes(ctx, { store: {}, sites: () => [] }), true);
-	assert.deepEqual(waitedFor, ["webServer"]);
+	assert.deepEqual(waitedFor, ["httpServer"]);
 	assert.equal(registered.length, 1, "the routes must register once the service arrives");
 	assert.equal(registered[0].path, USAGE_PATH);
 });


### PR DESCRIPTION
Closes #26。**两个独立的 bug 叠在同一条路径上**,都不出声,浏览器半边全程健康。

## Bug 1:服务名写错了

```js
ctx.inject(["webServer"], ...)   // 等一个不存在的服务
```

宿主提供的叫 **`httpServer`**。`@deepseek-ai/dsh-host-webserver` 的源码:

```js
var HttpServerService = class extends Service {
	constructor(ctx, config) {
		super(ctx, "httpServer");
```

**包名叫 webserver,服务名叫 httpServer。** 我照着包名猜了服务名。

顺手把我们用到的所有服务名都对着上游核了一遍:

| 我们用的 | 上游 `super(ctx, ...)` | |
| --- | --- | --- |
| `sessionPersistence` | `sessionPersistence` | ✅ |
| `settings` | `settings` | ✅ |
| `credentials` | `credentials` | ✅ |
| `llm` | `llm` | ✅ |
| `workspace` | `workspace` | ✅ |
| `commands` | `commands` | ✅ |
| **`webServer`** | **`httpServer`** | ❌ |

只错这一个。

## Bug 2:一个更早的 ReferenceError

```js
balance: createBalanceReader(ctx, {
	learnSoftware: fingerprints.learn,
	detect,          // <- 这个绑定不存在
})
```

`detect` 原本是 `apply()` 里的局部变量,**在"把指纹注册表提出去"那次重构(`b4232b9`)里被删掉了**,但这处引用留了下来。模块是严格模式,这是个 ReferenceError,在 `registerRoutes` 被调用的那一刻就抛。

所以**从那次重构起,HTTP 路由就一次也没注册成功过**。服务名写错这件事,一直躲在一个本来就会让它失败的 bug 后面。

## 为什么两个都不出声

**第一个**:`ctx.inject(name, cb)` 在 Cordis 里是 `this.plugin({inject, apply: cb})`——**它开子 fiber**。而 DSH 的启动断言只检查**顶层 entry**。子 fiber 可以永远 PENDING,entry 照样报"已激活"。

**第二个**:异常被这个 catch 吞了

```js
logger?.warn?.("tokenledger: could not register the HTTP routes: %s", error?.message ?? error);
```

这个 catch 存在是对的——面板坏了不该把宿主拖垮,它也确实做到了。但它把我们自己代码里的 ReferenceError 变成了一行灰字,路由缺了好几周没人发现。**被捕获的 bug 也得长得像 bug**,所以改成 `error` 级并带上 stack。

第三层:`registerRoutes` 排好 inject 后**立刻 `return true`**,所以 `plugin.js` 里那句兜底

```js
if (!served) logger?.info?.("tokenledger: no web server in this composition; ...")
```

永远不会打印。设计成兜底的那行,恰好在真的没服务时哑掉。

## 测试:又是同一个教训

守着"等的是哪个服务名"的那条测试,**从头到尾都是绿的**:

```js
assert.deepEqual(waitedFor, ["webServer"]);
```

它断言的是源码写了什么,不是契约是什么。和 #24 一模一样的失败,隔了一周。

所以新增的覆盖**不断言名字**,`test/boot.test.js` 加了 5 条:

1. 提供 `httpServer` → 断言两条路由**真的出现在那个服务上**(`kind: "exact"`、handler 是函数)
2. **真的调用 usage handler** → 断言 200,且 payload 里 `totals/windows/days/models/sites/projects/accounts/diagnostics` 一个不少。注册成功不等于能用——Bug 2 那种运行时错误只有真跑一遍才会现形
3. 非回环调用者 → 403(那道栅栏得在真实注册路径下也成立)
4. 把服务**换个名字**提供 → 断言什么都没注册,**而且插件照样 ACTIVE**。这条既证明第 1 条能失败,也把"为什么没人发现"钉成可执行的记录
5. 完全不给 HTTP 服务 → 照常激活(headless 组合不该依赖浏览器)

跑起来:

```
ok 4 - the panel's routes register against the service the host actually provides
ok 5 - the usage route answers a real request end to end
ok 6 - a non-loopback caller is refused by the route, not served
ok 7 - a service under any other name registers nothing, which is the whole bug
ok 8 - a headless composition still boots, just without the routes
```

全量 **390 全绿**。
