### PR TITLE
feat: 路由挂不上时不再无声——版本横幅 + 等待提示 + 十秒未果的诊断

### DIFF
--- a/src/http.js
+++ b/src/http.js
@@ -208,6 +208,39 @@ export function usagePayload(deps, query) {
 }
 
 /**
+ * Service names worth reporting when the one we want has not turned up.
+ *
+ * Not an exhaustive list of what a composition holds — there is no public way
+ * to enumerate that — but every name this package has ever reached for, plus
+ * the one it reached for wrongly. Printing which of these resolve turns "the
+ * panel 404s" into "the host provides `httpServer`, so we are asking for the
+ * wrong thing" or "this composition genuinely has no web server".
+ */
+const KNOWN_SERVICES = [
+	"httpServer",
+	"webServer",
+	"sessionPersistence",
+	"sessionQuery",
+	"settings",
+	"credentials",
+	"commands",
+	"llm",
+	"workspace"
+];
+
+/** Which of the names above this context can actually resolve. */
+function visibleServices(ctx) {
+	if (typeof ctx.get !== "function") return [];
+	return KNOWN_SERVICES.filter((name) => {
+		try {
+			return ctx.get(name) !== undefined;
+		} catch {
+			return false;
+		}
+	});
+}
+
+/**
  * Register the read-only routes, if this composition has a web server.
  *
  * `httpServer` is reached through a nested `inject` rather than the plugin's
@@ -236,7 +269,26 @@ export function registerRoutes(ctx, deps) {
 		if (immediate === undefined || typeof immediate.register !== "function") return false;
 		return attachRoutes(ctx, immediate, deps);
 	}
+	// A nested inject that never fires is invisible: no error, no log, and the
+	// only symptom is a 404 in a browser console that says nothing about the
+	// host. Twice now that has cost days. So the wait announces itself, and says
+	// so again if it is still waiting — with the services that DO exist, because
+	// "which name is right" is the question that was actually wrong both times.
+	deps.logger?.info?.("tokenledger: waiting for httpServer to serve %s", BASE_PATH);
+	let attached = false;
+	// Injectable so a test can reach this branch without sleeping through it.
+	const nagging = setTimeout(() => {
+		if (attached) return;
+		deps.logger?.warn?.(
+			"tokenledger: still no httpServer after 10s — the panel will 404. Services this context can see: %s",
+			visibleServices(ctx).join(", ") || "(none)"
+		);
+	}, deps.routeWaitMs ?? 10_000);
+	nagging.unref?.();
+
 	ctx.inject(["httpServer"], (scoped) => {
+		attached = true;
+		clearTimeout(nagging);
 		attachRoutes(scoped, scoped.httpServer, deps);
 		deps.logger?.info?.("tokenledger: serving %s and %s", USAGE_PATH, BALANCE_PATH);
 	});

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -31,7 +31,7 @@ import { createFingerprintRegistry } from "./fingerprints.js";
 import { describeProject, readProjectTitles } from "./projects.js";
 import { discoverFromContext, mergeSites, withKnownSoftware } from "./discovery.js";
 import { createBalanceReader, listAccounts } from "./balance.js";
-import { registerRoutes } from "./http.js";
+import { VERSION, registerRoutes } from "./http.js";
 import { LedgerStore } from "./store.js";
 import { RateTable, priceRows } from "./pricing.js";
 import { renderReport } from "./report.js";
@@ -492,6 +492,13 @@ export async function runCommand(rawInput, deps) {
 export function apply(ctx, userConfig = {}) {
 	const config = { ...DEFAULTS, ...userConfig };
 	const logger = ctx.logger?.("tokenledger") ?? ctx.logger;
+
+	// First line the host half prints, and it carries the version. Three
+	// separate rounds of debugging have ended at "the installed copy predates
+	// the fix", each time discovered only after the code was read again — a
+	// stale install and a broken one have identical symptoms, and this is the
+	// cheapest thing that tells them apart.
+	logger?.info?.("tokenledger %s: host half starting", VERSION);
 
 	let store;
 	try {

--- a/test/http.test.js
+++ b/test/http.test.js
@@ -233,6 +233,55 @@ test("the web server is waited for, not sampled at mount", async () => {
 	assert.equal(registered[0].path, USAGE_PATH);
 });
 
+test("a wait that never ends says so, and names what the context does have", async () => {
+	// The failure mode that cost two rounds: a nested inject fiber hangs, the
+	// entry still reads as activated, and the only symptom is a 404 in a browser
+	// console that says nothing about the host. Both times the cause was asking
+	// for the wrong service NAME while the right service sat right there — so
+	// the warning lists what resolves, which makes the mismatch the first thing
+	// you read.
+	const logged = [];
+	const ctx = {
+		get: (name) => (name === "webServer" || name === "settings" ? {} : undefined),
+		inject: () => {}, // scheduled and never fires, exactly like the real bug
+		effect: (fn) => fn()
+	};
+	registerRoutes(ctx, {
+		store: {},
+		sites: () => [],
+		routeWaitMs: 1,
+		logger: { info: (...a) => logged.push(a.join(" ")), warn: (...a) => logged.push(a.join(" ")) }
+	});
+
+	assert.ok(logged.some((line) => line.includes("waiting for httpServer")), "the wait has to announce itself");
+	await new Promise((resolve) => setTimeout(resolve, 20));
+
+	const nag = logged.find((line) => line.includes("still no httpServer"));
+	assert.ok(nag, "a wait that never ends must eventually say so");
+	assert.ok(nag.includes("webServer"), "and name the service that IS there, which is the whole clue");
+	assert.equal(nag.includes("the panel will 404"), true, "in the words the symptom appears as");
+});
+
+test("the nag is cancelled once the routes attach", async () => {
+	// A warning after a successful start would be worse than none: the next
+	// person would learn to ignore it.
+	const logged = [];
+	const ctx = {
+		get: () => undefined,
+		inject: (deps, run) => run({ httpServer: { register: () => () => {} }, effect: (fn) => fn() }),
+		effect: (fn) => fn()
+	};
+	registerRoutes(ctx, {
+		store: {},
+		sites: () => [],
+		routeWaitMs: 1,
+		logger: { info: (...a) => logged.push(a.join(" ")), warn: (...a) => logged.push(a.join(" ")) }
+	});
+	await new Promise((resolve) => setTimeout(resolve, 20));
+	assert.equal(logged.some((line) => line.includes("still no httpServer")), false);
+	assert.ok(logged.some((line) => line.includes("serving")));
+});
+
 test("a Cordis without ctx.inject still registers immediately", async () => {
 	// Older harnesses, and the test doubles above. The fallback must not be a
 	// silent no-op.


### PR DESCRIPTION
Closes #28。

## 加了三行日志

```
[info] tokenledger 0.1.0: host half starting
[info] tokenledger: waiting for httpServer to serve /api/tokenledger
[info] tokenledger: serving /api/tokenledger/usage and /api/tokenledger/balance
```

挂不上时第三行不出现，取而代之的是：

```
[WARN] tokenledger: still no httpServer after 10s — the panel will 404.
       Services this context can see: webServer, sessionPersistence, settings
```

**最后那半句是重点。** 两次事故的根因都是"要了一个不存在的服务名，而对的服务就在旁边"。把能看见的服务列出来，这个矛盾就是第一眼看到的东西，而不是查到最后才发现的。

## 为什么需要这个

嵌套的 `ctx.inject` 不触发时：没有异常、没有日志、顶层 entry 照样报激活。唯一症状是浏览器里两个 404，而 404 对宿主发生了什么一个字都没说。

版本横幅同理：三轮排查最后停在"装的是旧版"，而**旧版和坏版的症状完全一样**。

## 细节

- 挂上后取消那个警告——启动正常还报警只会教会大家忽略警告，有测试守着。
- 延时可注入（`routeWaitMs`），所以那个分支是**跑出来**的不是**描述出来**的。
- 列举的服务名是本包用过的全部，外加用错的那个 `webServer`——没有公开 API 能枚举 context 里的全部服务。

392 全绿。