### PR TITLE
fix: web 服务与工作区注册表的两个名字都接受（我核错了版本）

### DIFF
--- a/src/http.js
+++ b/src/http.js
@@ -208,6 +208,25 @@ export function usagePayload(deps, query) {
 }
 
 /**
+ * What the host's HTTP route registry is called, newest name first.
+ *
+ * Both are real. `@deepseek-ai/dsh-host-webserver@0.1.0-rc.6` — the line an
+ * 0.1.0-rc.6 harness composes — does `super(ctx, "webServer")`; the 0.0.1-rc.x
+ * line, which npm's `latest` tag still points at, says `httpServer`. Neither is
+ * a guess and neither can be dropped: a plugin installed beside either has to
+ * work.
+ *
+ * The way this was got wrong is worth more than the fix. `npm pack <pkg>`
+ * resolves the **`latest` dist-tag**, and for these packages `latest` is an
+ * OLDER line than the 0.1.0-rc.x actually in use. Reading the service name out
+ * of it looked like verification against upstream and was verification against
+ * a different version — so a correct name was "fixed" into a broken one while
+ * a sibling plugin in the same profile was serving 200s off the correct one.
+ * Check the version the composition resolves, not the one npm hands you.
+ */
+const WEB_SERVER_NAMES = ["webServer", "httpServer"];
+
+/**
  * Service names worth reporting when the one we want has not turned up.
  *
  * Not an exhaustive list of what a composition holds — there is no public way
@@ -217,14 +236,14 @@ export function usagePayload(deps, query) {
  * wrong thing" or "this composition genuinely has no web server".
  */
 const KNOWN_SERVICES = [
-	"httpServer",
-	"webServer",
+	...WEB_SERVER_NAMES,
 	"sessionPersistence",
 	"sessionQuery",
 	"settings",
 	"credentials",
 	"commands",
 	"llm",
+	"workspaceRegistry",
 	"workspace"
 ];
 
@@ -243,55 +262,55 @@ function visibleServices(ctx) {
 /**
  * Register the read-only routes, if this composition has a web server.
  *
- * `httpServer` is reached through a nested `inject` rather than the plugin's
- * own, for the same reason `commands` and `settings` are sampled: a headless
- * composition must still collect usage, and Cordis's `inject` has no optional
- * form, so a required declaration would refuse to load without a browser.
+ * Reached through a nested `inject` rather than the plugin's own, for the same
+ * reason `commands` and `settings` are: a headless composition must still
+ * collect usage, and Cordis's `inject` has no optional form, so a required
+ * declaration would refuse to load without a browser.
  *
- * @returns whether the routes were registered.
+ * @returns whether a wait was scheduled or the routes attached immediately.
  */
 export function registerRoutes(ctx, deps) {
-	// The service is `httpServer`. The PACKAGE is `dsh-host-webserver`, and
-	// naming the service after the package — `webServer` — is what shipped, so
-	// the nested fiber below waited on a name nothing provides and the routes
-	// were never registered. Upstream is unambiguous: `super(ctx, "httpServer")`.
-	//
-	// Nothing reported it. A nested `ctx.inject` is its own fiber, and DSH's
-	// activation assertion only covers top-level entries, so the host half
-	// "loaded" while the panel got a 404 from routes that did not exist.
-	//
-	// WAITED FOR, not sampled, for the separate reason recorded below: `ctx.get`
-	// at mount time answers undefined for a service that mounts later, which is
-	// how this same route silently vanished twice before. Name and lookup form
-	// are two independent ways to get this wrong and both have now been wrong.
 	if (typeof ctx.inject !== "function") {
-		const immediate = typeof ctx.get === "function" ? ctx.get("httpServer") : undefined;
-		if (immediate === undefined || typeof immediate.register !== "function") return false;
-		return attachRoutes(ctx, immediate, deps);
+		for (const name of WEB_SERVER_NAMES) {
+			const immediate = typeof ctx.get === "function" ? ctx.get(name) : undefined;
+			if (immediate !== undefined && typeof immediate.register === "function") return attachRoutes(ctx, immediate, deps);
+		}
+		return false;
 	}
+
 	// A nested inject that never fires is invisible: no error, no log, and the
 	// only symptom is a 404 in a browser console that says nothing about the
-	// host. Twice now that has cost days. So the wait announces itself, and says
-	// so again if it is still waiting — with the services that DO exist, because
-	// "which name is right" is the question that was actually wrong both times.
-	deps.logger?.info?.("tokenledger: waiting for httpServer to serve %s", BASE_PATH);
+	// host. So the wait announces itself, and says so again if it is still
+	// waiting — listing the services that DO exist, because "which name" is the
+	// question that has been wrong every single time.
+	deps.logger?.info?.("tokenledger: waiting for %s to serve %s", WEB_SERVER_NAMES.join(" or "), BASE_PATH);
 	let attached = false;
 	// Injectable so a test can reach this branch without sleeping through it.
 	const nagging = setTimeout(() => {
 		if (attached) return;
 		deps.logger?.warn?.(
-			"tokenledger: still no httpServer after 10s — the panel will 404. Services this context can see: %s",
+			"tokenledger: still no web server after 10s — the panel will 404. Services this context can see: %s",
 			visibleServices(ctx).join(", ") || "(none)"
 		);
 	}, deps.routeWaitMs ?? 10_000);
 	nagging.unref?.();
 
-	ctx.inject(["httpServer"], (scoped) => {
-		attached = true;
-		clearTimeout(nagging);
-		attachRoutes(scoped, scoped.httpServer, deps);
-		deps.logger?.info?.("tokenledger: serving %s and %s", USAGE_PATH, BALANCE_PATH);
-	});
+	// One wait per name, first to arrive wins. Both are real: whichever this
+	// composition happens to provide is the right one, and asking for only the
+	// other is precisely how the panel 404'd for a week.
+	for (const name of WEB_SERVER_NAMES) {
+		ctx.inject([name], (scoped) => {
+			// Both the already-attached case and the wrong-shape case. Two waits
+			// are outstanding and only one composition can satisfy either, so the
+			// callback has to be able to decline.
+			const server = scoped?.[name];
+			if (attached || server === undefined || typeof server.register !== "function") return;
+			attached = true;
+			clearTimeout(nagging);
+			attachRoutes(scoped, server, deps);
+			deps.logger?.info?.("tokenledger: serving %s and %s via %s", USAGE_PATH, BALANCE_PATH, name);
+		});
+	}
 	return true;
 }
 

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -28,7 +28,7 @@
 import { applyUsageDelta, dayKey } from "./usage.js";
 import { RelaySiteRegistry, SITE_TYPES, createSiteResolver, domainOf } from "./relay-sites.js";
 import { createFingerprintRegistry } from "./fingerprints.js";
-import { describeProject, readProjectTitles } from "./projects.js";
+import { describeProject, readProjectTitles, workspaceRegistry } from "./projects.js";
 import { discoverFromContext, mergeSites, withKnownSoftware } from "./discovery.js";
 import { createBalanceReader, listAccounts } from "./balance.js";
 import { VERSION, registerRoutes } from "./http.js";
@@ -592,7 +592,7 @@ export function apply(ctx, userConfig = {}) {
 	const refreshProjectTitles = async () => {
 		try {
 			const paths = store.byProject({}).map((row) => row.project);
-			projectTitles = await readProjectTitles(paths, ctx.get?.("workspace"));
+			projectTitles = await readProjectTitles(paths, workspaceRegistry(ctx));
 		} catch (error) {
 			// A row keeps its directory name. Nothing about the usage it holds is
 			// less true for want of a nicer label.

--- a/src/projects.js
+++ b/src/projects.js
@@ -40,6 +40,36 @@
  * @module dsh-tokenledger/projects
  */
 
+/**
+ * What the workspace registry is called, newest name first.
+ *
+ * `@deepseek-ai/dsh-workspace@0.1.0-rc.6` provides `workspaceRegistry`; the
+ * 0.0.1-rc.x line that npm's `latest` tag points at provides `workspace`. The
+ * API is identical — `resolveByPath`, `list`, `get` — so only the name has to
+ * be tolerated, and asking for only one of them meant project titles silently
+ * never resolved and every row fell back to its directory name.
+ */
+const REGISTRY_NAMES = ["workspaceRegistry", "workspace"];
+
+/**
+ * The workspace registry this composition provides, under whichever name.
+ *
+ * @param ctx - the Cordis context.
+ * @returns the service, or undefined — which is a supported state, not a fault.
+ */
+export function workspaceRegistry(ctx) {
+	if (typeof ctx?.get !== "function") return undefined;
+	for (const name of REGISTRY_NAMES) {
+		try {
+			const found = ctx.get(name);
+			if (found !== undefined) return found;
+		} catch {
+			// A context that refuses an undeclared name simply has not got it.
+		}
+	}
+	return undefined;
+}
+
 /** Last path segment, for either separator. */
 export function basename(path) {
 	const parts = String(path).split(/[\\/]+/).filter((segment) => segment !== "");

--- a/test/boot.test.js
+++ b/test/boot.test.js
@@ -165,16 +165,49 @@ test("a non-loopback caller is refused by the route, not served", async () => {
 	}
 });
 
-test("a service under any other name registers nothing, which is the whole bug", async () => {
-	// Proves the test above can fail. Provided as `webServer`, the routes do not
-	// appear — and the plugin still activates, which is exactly why this went
-	// unnoticed: a nested inject fiber is not an entry, so DSH's activation
-	// assertion never sees it hanging.
-	const webServer = httpServerStub();
-	const { ctx, fiber } = await boot(plugin, { sessionPersistence: persistence, webServer });
+test("either real name for the host's route registry works", async () => {
+	// `dsh-host-webserver@0.1.0-rc.6` provides `webServer`; the 0.0.1-rc.x line
+	// that npm's `latest` tag points at provides `httpServer`. Both are real,
+	// and asking for only one of them is how this panel 404'd for a week — the
+	// name was "verified" against a version the harness does not compose.
+	for (const name of ["webServer", "httpServer"]) {
+		const server = httpServerStub();
+		const { ctx, fiber } = await boot(plugin, { sessionPersistence: persistence, [name]: server });
+		try {
+			assert.equal(fiber.state, ACTIVE, name);
+			assert.deepEqual(
+				server.routes.map((route) => route.path).sort(),
+				["/api/tokenledger/balance", "/api/tokenledger/usage"],
+				`no routes registered against ${name}`
+			);
+		} finally {
+			await ctx.fiber?.dispose?.();
+		}
+	}
+});
+
+test("a name that is not one of them registers nothing, and still boots", async () => {
+	// Proves the test above can fail, and records why nothing reported the
+	// original bug: a nested inject fiber is not an entry, so DSH's activation
+	// assertion never sees it hanging. The plugin looks perfectly healthy.
+	const server = httpServerStub();
+	const { ctx, fiber } = await boot(plugin, { sessionPersistence: persistence, someOtherServer: server });
 	try {
 		assert.equal(fiber.state, ACTIVE, "it boots perfectly happily, serving nothing");
-		assert.deepEqual(webServer.routes, []);
+		assert.deepEqual(server.routes, []);
+	} finally {
+		await ctx.fiber?.dispose?.();
+	}
+});
+
+test("only one registration happens when both names are present", async () => {
+	// Two waits are outstanding. A composition providing both must not get the
+	// routes twice — the host throws on a duplicate path.
+	const webServer = httpServerStub();
+	const httpServer = httpServerStub();
+	const { ctx } = await boot(plugin, { sessionPersistence: persistence, webServer, httpServer });
+	try {
+		assert.equal(webServer.routes.length + httpServer.routes.length, 2, "registered twice, which the host rejects");
 	} finally {
 		await ctx.fiber?.dispose?.();
 	}

--- a/test/http.test.js
+++ b/test/http.test.js
@@ -242,7 +242,7 @@ test("a wait that never ends says so, and names what the context does have", asy
 	// you read.
 	const logged = [];
 	const ctx = {
-		get: (name) => (name === "webServer" || name === "settings" ? {} : undefined),
+		get: (name) => (name === "settings" || name === "llm" ? {} : undefined),
 		inject: () => {}, // scheduled and never fires, exactly like the real bug
 		effect: (fn) => fn()
 	};
@@ -253,12 +253,14 @@ test("a wait that never ends says so, and names what the context does have", asy
 		logger: { info: (...a) => logged.push(a.join(" ")), warn: (...a) => logged.push(a.join(" ")) }
 	});
 
-	assert.ok(logged.some((line) => line.includes("waiting for httpServer")), "the wait has to announce itself");
+	const waiting = logged.find((line) => line.includes("waiting for"));
+	assert.ok(waiting, "the wait has to announce itself");
+	assert.ok(waiting.includes("webServer or httpServer"), "and name every name it will accept");
 	await new Promise((resolve) => setTimeout(resolve, 20));
 
-	const nag = logged.find((line) => line.includes("still no httpServer"));
+	const nag = logged.find((line) => line.includes("still no web server"));
 	assert.ok(nag, "a wait that never ends must eventually say so");
-	assert.ok(nag.includes("webServer"), "and name the service that IS there, which is the whole clue");
+	assert.ok(nag.includes("settings"), "and name the services that ARE there, which is the whole clue");
 	assert.equal(nag.includes("the panel will 404"), true, "in the words the symptom appears as");
 });
 
@@ -278,7 +280,7 @@ test("the nag is cancelled once the routes attach", async () => {
 		logger: { info: (...a) => logged.push(a.join(" ")), warn: (...a) => logged.push(a.join(" ")) }
 	});
 	await new Promise((resolve) => setTimeout(resolve, 20));
-	assert.equal(logged.some((line) => line.includes("still no httpServer")), false);
+	assert.equal(logged.some((line) => line.includes("still no web server")), false);
 	assert.ok(logged.some((line) => line.includes("serving")));
 });
 

--- a/test/packaging.test.js
+++ b/test/packaging.test.js
@@ -69,7 +69,7 @@ test("only services the plugin genuinely cannot start without are injected", asy
 	assert.equal(inject.includes("workspace"), false, "titles are a nicety; requiring them would trade the panel for a label");
 
 	const source = readFileSync(new URL("../src/plugin.js", import.meta.url), "utf8");
-	assert.match(source, /ctx\.get\?\.\("workspace"\)/, "and it has to actually be read through the tolerant door");
+	assert.match(source, /workspaceRegistry\(ctx\)/, "and it has to actually be read through the tolerant door");
 });
 
 test("declaring dsh.client obliges the package to export ./client", () => {

--- a/test/projects.test.js
+++ b/test/projects.test.js
@@ -12,7 +12,7 @@ import { DatabaseSync } from "node:sqlite";
 import test from "node:test";
 
 import { LedgerStore, normalizeProject } from "../src/store.js";
-import { basename, describeProject, readProjectTitles } from "../src/projects.js";
+import { basename, describeProject, readProjectTitles, workspaceRegistry } from "../src/projects.js";
 import { applyUsageDelta } from "../src/usage.js";
 
 const DAY = "2026-08-17";
@@ -227,6 +227,34 @@ test("basename handles both separators and a trailing one", () => {
 	assert.equal(basename("C:\\work\\ledger"), "ledger");
 	assert.equal(basename("/home/me/ledger/"), "ledger");
 	assert.equal(basename("ledger"), "ledger");
+});
+
+test("the workspace registry is found under either name it has shipped as", async () => {
+	// `dsh-workspace@0.1.0-rc.6` provides `workspaceRegistry`; the 0.0.1-rc.x
+	// line npm's `latest` points at provides `workspace`. The API is identical,
+	// so only the name has to be tolerated — and asking for only one meant
+	// titles silently never resolved and every row fell back to its directory.
+	for (const name of ["workspaceRegistry", "workspace"]) {
+		const service = { resolveByPath: async () => ({ title: "Found" }) };
+		const ctx = { get: (asked) => (asked === name ? service : undefined) };
+		assert.equal(workspaceRegistry(ctx), service, name);
+		assert.equal((await readProjectTitles(["/a"], workspaceRegistry(ctx))).get("/a"), "Found", name);
+	}
+});
+
+test("the newer name wins when a composition somehow has both", async () => {
+	const registry = { resolveByPath: async () => undefined };
+	const legacy = { resolveByPath: async () => undefined };
+	const ctx = { get: (asked) => (asked === "workspaceRegistry" ? registry : asked === "workspace" ? legacy : undefined) };
+	assert.equal(workspaceRegistry(ctx), registry);
+});
+
+test("no registry under any name is undefined, not a throw", async () => {
+	assert.equal(workspaceRegistry({ get: () => undefined }), undefined);
+	assert.equal(workspaceRegistry({}), undefined);
+	assert.equal(workspaceRegistry(undefined), undefined);
+	// A context that refuses an undeclared name simply has not got it.
+	assert.equal(workspaceRegistry({ get: () => { throw new Error("not injected"); } }), undefined);
 });
 
 test("titles are looked up once per directory, not once per session", async () => {


### PR DESCRIPTION
Closes #30。

## 我核错了版本

`npm pack @deepseek-ai/<pkg>` 不带版本时解析 **`latest` dist-tag**，而这些包的 `latest` 指向 `0.0.1-rc.x`——**比用户实际在跑的 `0.1.0-rc.6` 更老的一条线**。看起来像是在对着上游核实，实际是在对着另一个版本核实。

| 包 | latest | **0.1.0-rc.6（实际）** |
| --- | --- | --- |
| `dsh-host-webserver` | `httpServer` | **`webServer`** |
| `dsh-workspace` | `workspace` | **`workspaceRegistry`** |

所以 **#27 把一个正确的名字改成了错的**。#27 里真正的 bug 只有 `detect` 那个 ReferenceError——两个缺陷产生同样的 404，修掉一个又引入另一个，症状一点没变。

**证据一直摆在那儿**：同一个 profile 里的另一个插件用 `ctx.webServer.register(...)`，它的路由返回 200。我在动手之前就该去看它用的什么名字。

#22 也有同样的毛病，只是更安静：`ctx.get("workspace")` 在 rc.6 上永远返回 undefined，按项目那段的工作区标题从来没生效过，一直退回目录名。不致命（本来就是可选的），所以完全不可见。

## 改法

两个名字都接受，新的优先——它们**都是真实发行过的名字**，不是猜出来的兼容层。两个版本的 API 完全一样，只有名字不同。

web 服务那边是每个名字一个 wait、先到先得，而且回调**会拒绝**而不是假设：

```js
const server = scoped?.[name];
if (attached || server === undefined || typeof server.register !== "function") return;
```

两个 wait 同时挂着，而一个组合只可能满足其中一个。注册两次会抛——宿主拒绝重复路径。

## 测试

- 两个名字**各启动一次**，断言路由真的挂上（`ok 7`）
- 用**第三个名字**启动，断言什么都没注册、且插件照样 ACTIVE（`ok 8`）——这条既证明前面能失败，也记录了为什么当初没人发现
- **两个名字都给**，断言只注册一次（`ok 9`）
- 工作区两个名字各一条，外加"都有时新的赢"和"一个都没有时返回 undefined 而不是抛"

397 全绿。我也在真 Cordis 上用 `webServer` 跑了一遍：

```
[info] tokenledger 0.1.0: host half starting
[info] tokenledger: waiting for webServer or httpServer to serve /api/tokenledger
[info] tokenledger: serving /api/tokenledger/usage and /api/tokenledger/balance via webServer
routes registered: ["/api/tokenledger/usage","/api/tokenledger/balance"]
```