### PR TITLE
feat: 诊断打印「哪条路由归到了哪个站点」

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,14 @@ dsh plugin --profile web update dsh-tokenledger
 dsh plugin --profile web remove dsh-tokenledger
 ```
 
+`update` 对 git 依赖不一定会重新解析（包管理器可能认为 spec 字符串没变就不用动）。**想确定拿到某个版本，钉 commit：**
+
+```bash
+dsh plugin --profile web add "github:zh667/TokenLedger#<commit>"
+```
+
+装完之后 `/tokenledger diagnostics` 会打印当前的路由归属和索引里的路由——**排查「我的中转站为什么不显示」看这里**，不用猜。
+
 装完即可用：没有要填的配置，也不需要任何凭据就能看到全部用量与中转站分布。余额是唯一用到 key 的地方，而那把 key 宿主已经替你存着了。
 
 ## 命令 / Commands

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -33,7 +33,7 @@
  * @module dsh-tokenledger/plugin
  */
 
-import { applyUsageDelta, dayKey } from "./usage.js";
+import { DIRECT, UNROUTED, applyUsageDelta, dayKey } from "./usage.js";
 import { RelaySiteRegistry, SITE_TYPES, createSiteResolver, domainOf } from "./relay-sites.js";
 import { createFingerprintRegistry } from "./fingerprints.js";
 import { describeProject, readProjectTitles, workspaceRegistry } from "./projects.js";
@@ -42,7 +42,7 @@ import { createBalanceReader, listAccounts } from "./balance.js";
 import { VERSION, registerRoutes } from "./http.js";
 import { LedgerStore } from "./store.js";
 import { RateTable, priceRows } from "./pricing.js";
-import { renderReport } from "./report.js";
+import { num, renderReport, table } from "./report.js";
 
 /** `YYYY-MM-DD` for N days before today, in local time. */
 function dayKeyDaysAgo(daysBack) {
@@ -431,7 +431,9 @@ export async function runCommand(rawInput, deps) {
 			// Worth its own line: rows that could not be attributed are the one
 			// number that says the fold is missing something, rather than that
 			// there was nothing to find.
-			`  归因不上的行     ${d.unattributedRows}${d.unattributedRows > 0 ? "  ← 这些行的 provider 或 model 是 unknown" : ""}`
+			`  归因不上的行     ${d.unattributedRows}${d.unattributedRows > 0 ? "  ← 这些行的 provider 或 model 是 unknown" : ""}`,
+			"",
+			...routeAttributionReport(store, deps.directory?.())
 		].join("\n");
 	}
 
@@ -488,6 +490,68 @@ export async function runCommand(rawInput, deps) {
 		priced: config.rates === undefined ? null : priceWithConfiguredRates(store, range, site, config.rates),
 		siteFilter: site
 	});
+}
+
+/**
+ * The two tables that answer "why is my relay not showing".
+ *
+ * Neither number was reachable before. Working out where a site's traffic had
+ * gone meant reasoning about the resolver from the outside, three rounds of it,
+ * while the answer sat in the index the whole time: **the rollup row keys on
+ * the route name**, so which routes landed in which bucket has always been
+ * recorded and simply never displayed.
+ *
+ * @param store - the ledger.
+ * @param directory - the live relay directory, or undefined if not wired.
+ */
+function routeAttributionReport(store, directory) {
+	const out = ["── 路由归属（当前配置）──"];
+	const baseUrls = directory?.providerBaseUrls ?? {};
+	const routes = Object.keys(baseUrls).sort();
+
+	if (routes.length === 0) {
+		out.push("  自动发现没有看到任何带 baseURL 的 provider 路由。");
+		out.push("  这本身可能是对的（只用官方直连），也可能是 settings 服务缺席或 provider 由 agent preset 挂载。");
+	} else {
+		const rows = routes.map((route) => {
+			const site = directory?.resolveSite?.(route);
+			const where = site === undefined ? "未知路由" : site === DIRECT ? "直连/官方（不指向中转站）" : site;
+			return [route, String(baseUrls[route]), where];
+		});
+		out.push(...table([{ title: "路由" }, { title: "baseURL" }, { title: "归到" }], rows).map((l) => `  ${l}`));
+	}
+
+	// What the index actually holds, which is the half that says whether the
+	// CURRENT configuration ever applied to the traffic already recorded.
+	const byRoute = new Map();
+	for (const row of store.byRoute()) {
+		const key = `${row.site} ${row.provider}`;
+		byRoute.set(key, (byRoute.get(key) ?? 0) + (row.tokens ?? 0));
+	}
+	out.push("", "── 索引里的路由（历史流量实际记在哪）──");
+	if (byRoute.size === 0) {
+		out.push("  索引里还没有任何用量。");
+		return out;
+	}
+	const indexed = [...byRoute]
+		.sort((a, b) => b[1] - a[1])
+		.map(([key, tokens]) => {
+			const [site, ...rest] = key.split(" ");
+			const label = site === DIRECT ? "直连/官方" : site === UNROUTED ? "未知路由" : site;
+			return [label, rest.join(" "), num(tokens)];
+		});
+	out.push(
+		...table([{ title: "站点" }, { title: "路由" }, { title: "tokens", align: "right" }], indexed).map((l) => `  ${l}`)
+	);
+	// The line that turns a puzzling breakdown into an actionable one.
+	const stranded = [...byRoute.keys()].filter((k) => k.startsWith(`${DIRECT} `) || k.startsWith(`${UNROUTED} `));
+	if (stranded.length > 0) {
+		out.push("");
+		out.push("  上面记在「直连/官方」或「未知路由」下的路由名，如果其实是中转站，");
+		out.push("  说明折叠那批流量时目录里没有它。用同一个路由名把它配回去，");
+		out.push("  下一次目录变化会重建索引并让历史流量归位。");
+	}
+	return out;
 }
 
 /**
@@ -781,6 +845,9 @@ export function apply(ctx, userConfig = {}) {
 			reindex: api.reindex,
 			logger,
 			sites: () => directory.sites,
+			// The whole directory, not just its sites: diagnostics needs the
+			// route -> baseUrl map and the resolver to explain an attribution.
+			directory: () => directory,
 			projectTitles: () => projectTitles,
 			refresh: () => void refreshDirectory(),
 			settle: fingerprints.settle,

--- a/test/report.test.js
+++ b/test/report.test.js
@@ -123,6 +123,70 @@ const seeded = () => {
 	return store;
 };
 
+test("diagnostics says which route landed in which bucket", async () => {
+	// Three rounds of debugging a missing relay row went by without this,
+	// reasoning about the resolver from the outside — while the answer sat in
+	// the index the whole time, because the rollup row keys on the ROUTE name.
+	const { LedgerStore } = await import("../src/store.js");
+	const { RelaySiteRegistry, createSiteResolver } = await import("../src/relay-sites.js");
+	const { applyUsageDelta } = await import("../src/usage.js");
+
+	const registry = new RelaySiteRegistry([{ id: "relay.example", type: "newapi", baseUrl: "https://relay.example/v1" }]);
+	const providerBaseUrls = { nine: "https://relay.example/v1", official: "https://api.deepseek.com" };
+	const directory = { sites: registry.list(), providerBaseUrls, resolveSite: createSiteResolver(registry, providerBaseUrls) };
+
+	const store = LedgerStore.open(":memory:");
+	try {
+		// Folded when the directory did NOT yet know the relay, which is how the
+		// traffic ends up somewhere its current configuration disagrees with.
+		const past = createSiteResolver(new RelaySiteRegistry([]), {});
+		const state = store.loadState("s1");
+		applyUsageDelta(
+			state,
+			[
+				{
+					seq: 1,
+					time: Date.parse("2026-08-17T10:00:00Z"),
+					type: "assistant/message",
+					data: { turn: 1, step: 1, message: { role: "assistant", source: { kind: "model", provider: "nine", model: "v4" } }, usage: { inputTokens: 900, outputTokens: 0 } }
+				}
+			],
+			{ resolveSite: past }
+		);
+		store.commitSession("s1", state, {});
+
+		const text = await runCommand("diagnostics", { store, sites: () => directory.sites, directory: () => directory });
+
+		// Half one: what the CURRENT configuration says.
+		assert.match(text, /路由归属/);
+		assert.match(text, /nine\s+https:\/\/relay\.example\/v1\s+relay\.example/, "the route resolves now");
+		assert.match(text, /official\s+https:\/\/api\.deepseek\.com\s+直连/, "and this one really is direct");
+
+		// Half two: where the traffic actually sits, which is the half that
+		// exposes the disagreement.
+		assert.match(text, /索引里的路由/);
+		assert.match(text, /未知路由\s+nine\s+900/, "the route name is what makes this diagnosable");
+		assert.match(text, /用同一个路由名把它配回去/, "and it has to say what to do about it");
+	} finally {
+		store.close();
+	}
+});
+
+test("diagnostics is honest when there is no directory to report", async () => {
+	const { LedgerStore } = await import("../src/store.js");
+	const store = LedgerStore.open(":memory:");
+	try {
+		const text = await runCommand("diagnostics", { store, sites: () => [] });
+		assert.match(text, /自动发现没有看到任何带 baseURL 的 provider 路由/);
+		assert.match(text, /索引里还没有任何用量/);
+		// A composition with no relays is a normal state, not a fault, and the
+		// wording has to leave room for that while naming the other causes.
+		assert.match(text, /这本身可能是对的/);
+	} finally {
+		store.close();
+	}
+});
+
 test("the command renders a report from the store", async () => {
 	const store = seeded();
 	try {


### PR DESCRIPTION
Closes #36。

排查「中转站为什么不显示」花了三轮，全靠从外部推理 resolver，**因为产品里没有任何一处能被问到这个问题**。而答案一直在索引里：汇总行按路由名存，谁落在哪个桶里从来都记着，只是没显示过。

## 两张表

**当前配置怎么解析**

```
── 路由归属（当前配置）──
  路由      baseURL                   归到
  nine      https://api.9zyx.xyz/v1   api.9zyx.xyz
  official  https://api.deepseek.com  直连/官方（不指向中转站）
  ooioo     https://ooioo.work/v1     ooioo.work
```

三种结果是三种不同的诊断：命中站点 / 真直连 / **路由不在目录里**（自动发现看不到它——agent preset 挂的、或 settings 服务缺席）。

**索引里实际记在哪**

```
── 索引里的路由（历史流量实际记在哪）──
  站点        路由    tokens
  未知路由    nine   352,464
  ooioo.work  ooioo   46,514

  上面记在「直连/官方」或「未知路由」下的路由名，如果其实是中转站，
  说明折叠那批流量时目录里没有它。用同一个路由名把它配回去，
  下一次目录变化会重建索引并让历史流量归位。
```

**这一半才是关键**：它暴露两者的分歧。一条今天解析得好好的路由，历史却记在「未知路由」下，说明折叠那批流量时目录里还没有它。

## 细节

- 用 `report.js` 现成的 CJK 宽度感知 `table()`，不手动 padEnd（中文列会错位）。
- 目录为空是**正常状态不是故障**，文案说清楚这一点的同时也列出其他可能原因。
- 只有计数和标识符，和这个仓库其他地方一样——不碰提示词、工具参数、凭据。

## README

补了一句诚实的说明：** 对 git 依赖不一定重新解析**，要确定版本就钉 commit。并指向 diagnostics 作为排查入口。

404 全绿。