### PR TITLE
docs: 短 commit SHA 不是可安装的 git ref

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,11 +43,18 @@ dsh plugin --profile web update dsh-tokenledger
 dsh plugin --profile web remove dsh-tokenledger
 ```
 
-`update` 对 git 依赖不一定会重新解析（包管理器可能认为 spec 字符串没变就不用动）。**想确定拿到某个版本，钉 commit：**
+重装同一个 spec 会重新解析，所以 `add` 一遍就能拿到最新的 `main`（实测过，不是推测）。
 
-```bash
-dsh plugin --profile web add "github:zh667/TokenLedger#<commit>"
-```
+**要钉某个版本，必须用完整的 40 位 commit SHA。** 包管理器把 ref 拿去和 `git ls-remote` 广播的引用列表比对，而那份列表里只有完整 SHA 和分支/标签名——**短 SHA 匹配不到任何东西，会直接报 `Could not resolve`**：
+
+| spec | |
+| --- | --- |
+| `github:zh667/TokenLedger` | ✅ |
+| `github:zh667/TokenLedger#main` | ✅ |
+| `github:zh667/TokenLedger#947247a` | ❌ 短 SHA 解析不了 |
+| `github:zh667/TokenLedger#947247a86f0835f0e746695538569b1a76356dd1` | ✅ |
+
+如果 `package.json` 里已经被写进了一个解析不了的 spec，`add` 也会失败——它会先解析整份清单。改掉那一行再 `install` 即可。
 
 装完之后 `/tokenledger diagnostics` 会打印当前的路由归属和索引里的路由——**排查「我的中转站为什么不显示」看这里**，不用猜。
 


### PR DESCRIPTION
Closes #38。

我让用户钉 `#947247a`，把他的 profile 弄坏了：

```
ERROR  Could not resolve 947247a to a commit of https://github.com/zh667/TokenLedger.git.
```

包管理器把 ref 和 `git ls-remote` 广播的引用列表比对，那里面只有**完整 40 位 SHA** 和分支/标签名，7 位前缀匹配不到任何东西。

四种形式都跑了一遍，没有推理：

| spec | |
| --- | --- |
| `github:zh667/TokenLedger` | ✅ |
| `github:zh667/TokenLedger#main` | ✅ |
| `github:zh667/TokenLedger#947247a` | ❌ |
| 完整 40 位 SHA | ✅ |

**顺带纠正上一条建议。** 同一个 spec 重装**确实会**重新解析——装一次、让 main 往前走、同目录再装，拿到了新 commit。那句关于 `update` 的告诫是我编的，没验证，而且把人引到了一条会往 profile 清单里写死一个解析不了的 spec 的路上。

也写了怎么恢复：`add` 修不了这个状态，因为它先解析整份清单，所以坏的那行得先改掉。