### PR TITLE
fix: 索引与目录不一致时重建，而不是只在 origin 集合变化时

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -33,7 +33,7 @@
  * @module dsh-tokenledger/plugin
  */
 
-import { DIRECT, UNROUTED, applyUsageDelta, dayKey } from "./usage.js";
+import { DIRECT, UNKNOWN, UNROUTED, applyUsageDelta, dayKey } from "./usage.js";
 import { RelaySiteRegistry, SITE_TYPES, createSiteResolver, domainOf } from "./relay-sites.js";
 import { createFingerprintRegistry } from "./fingerprints.js";
 import { describeProject, readProjectTitles, workspaceRegistry } from "./projects.js";
@@ -493,6 +493,37 @@ export async function runCommand(rawInput, deps) {
 }
 
 /**
+ * Rows whose recorded site is not what the directory would say today.
+ *
+ * The fold is INCREMENTAL — `readFrom(id, consumedSeq + 1)` appends only new
+ * events — so a session first folded when the directory did not know a route
+ * keeps those old rows forever while its later events attribute correctly. A
+ * real install ended up with one route under two different sites, 229k tokens
+ * of it labelled "direct/official".
+ *
+ * The old trigger compared the set of ORIGINS and rebuilt when it changed. That
+ * catches a relay being added or removed and misses this entirely: once the set
+ * settles, stale rows are never revisited no matter how plainly they disagree.
+ * So the disagreement itself is what gets checked.
+ *
+ * @param store - the ledger.
+ * @param directory - the live directory; its `resolveSite` is the authority.
+ * @returns `[{ site, provider, expected }]`, empty when the index agrees.
+ */
+export function staleAttributions(store, directory) {
+	// Discovery being down makes every route look unresolvable, which would
+	// "prove" the whole index stale and rebuild it into a worse state.
+	if (directory?.available !== true) return [];
+	const out = [];
+	for (const row of store.distinctRoutes()) {
+		if (row.provider === UNKNOWN) continue; // no route to resolve; DIRECT by rule
+		const expected = directory.resolveSite?.(row.provider) ?? UNROUTED;
+		if (expected !== row.site) out.push({ site: row.site, provider: row.provider, expected });
+	}
+	return out;
+}
+
+/**
  * The two tables that answer "why is my relay not showing".
  *
  * Neither number was reachable before. Working out where a site's traffic had
@@ -630,7 +661,7 @@ export function apply(ctx, userConfig = {}) {
 		}
 		const merged = mergeSites(discovered, normalizeRelayConfig(config));
 		merged.sites = withKnownSoftware(merged.sites, fingerprints.software);
-		const next = { ...merged, resolveSite: buildResolver(merged) };
+		const next = { ...merged, available: discovered.available === true, resolveSite: buildResolver(merged) };
 		const moved = directoryKnown && originKey(next) !== originKey(directory);
 
 		if (!directoryKnown && discovered.available && merged.sites.length > 0) {
@@ -683,8 +714,21 @@ export function apply(ctx, userConfig = {}) {
 			// the alternative is a report that shows a site starting from the
 			// moment it was noticed, which reads as "you just started using this"
 			// rather than "this was only just recognised".
-			if (refreshDirectory()) {
-				logger?.info?.("tokenledger: the relay set changed; rebuilding the index so past traffic is attributed too");
+			const moved = refreshDirectory();
+			// Two reasons to rebuild, and the second is the one that was missing.
+			// A changed relay set is the obvious case; an index that simply
+			// disagrees with the directory is the case that survives it.
+			const stale = moved ? [] : staleAttributions(store, directory);
+			if (moved || stale.length > 0) {
+				if (moved) {
+					logger?.info?.("tokenledger: the relay set changed; rebuilding the index so past traffic is attributed too");
+				} else {
+					logger?.info?.(
+						"tokenledger: %d route(s) are recorded under a site the directory no longer agrees with (%s); rebuilding",
+						stale.length,
+						stale.map((r) => `${r.provider}: ${r.site} -> ${r.expected}`).join(", ")
+					);
+				}
 				store.reset();
 			}
 			const stats = await sweep(ctx.sessionPersistence, store, {

--- a/src/store.js
+++ b/src/store.js
@@ -429,6 +429,18 @@ export class LedgerStore {
 	}
 
 	/**
+	 * Every `(site, provider)` pair the index holds.
+	 *
+	 * Small by construction — its size is the number of routes ever seen, not
+	 * the amount of traffic — so it is cheap enough to check on every sweep.
+	 * That matters, because it is the only way to notice that stored attribution
+	 * has drifted from what the directory would say today.
+	 */
+	distinctRoutes() {
+		return this.#db.prepare("SELECT DISTINCT site, provider FROM session_rollups").all();
+	}
+
+	/**
 	 * Index health, for the diagnostics surface. Deliberately counts and
 	 * identifiers only — never prompts, tool arguments, credentials, or content.
 	 */

--- a/test/plugin.test.js
+++ b/test/plugin.test.js
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { normalizeRelayConfig, sweep } from "../src/plugin.js";
+import { normalizeRelayConfig, staleAttributions, sweep } from "../src/plugin.js";
 import { LedgerStore } from "../src/store.js";
 import { RelaySiteRegistry, createSiteResolver } from "../src/relay-sites.js";
 
@@ -144,6 +144,75 @@ test("a listSnapshots failure degrades instead of throwing into DSH", async () =
 		const stats = await sweep(persistence, store, { logger: { warn() {} } });
 		assert.equal(stats.failed, 1);
 		assert.equal(stats.scanned, 0);
+	});
+});
+
+// --- the index can drift from the directory ------------------------------------
+
+/** A directory that resolves `nine` to a relay and knows nothing else. */
+function liveDirectory() {
+	const registry = new RelaySiteRegistry([{ id: "nine", type: "newapi", baseUrl: "https://api.relay-one.example/v1" }]);
+	const providerBaseUrls = { ninerelay: "https://api.relay-one.example/v1" };
+	return { available: true, providerBaseUrls, resolveSite: createSiteResolver(registry, providerBaseUrls) };
+}
+
+/** Fold `events` into a fresh store using `resolveSite`. */
+async function indexedWith(store, id, events, resolveSite) {
+	await sweep(fakePersistence(new Map([[id, { revision: id, events }]])), store, { resolveSite });
+}
+
+test("a route recorded under a site the directory no longer agrees with is stale", async () => {
+	// The shape a real install reached: the fold is INCREMENTAL, so a session
+	// first folded before the directory knew a route keeps those rows while its
+	// later events attribute correctly. One route, two sites, 229k tokens of it
+	// under "direct/official".
+	await withStore(async (store) => {
+		const directory = liveDirectory();
+		const blind = createSiteResolver(new RelaySiteRegistry([]), {});
+		await indexedWith(store, "s1", [header("ninerelay", "gpt"), message(1, 1, "ninerelay", "gpt", { inputTokens: 100, outputTokens: 0 })], blind);
+
+		const stale = staleAttributions(store, directory);
+		assert.deepEqual(stale, [{ site: "unrouted", provider: "ninerelay", expected: "nine" }]);
+	});
+});
+
+test("an index that agrees with the directory is not rebuilt", async () => {
+	// Without this the check would rebuild on every sweep, which is a rebuild
+	// loop wearing the costume of a fix.
+	await withStore(async (store) => {
+		const directory = liveDirectory();
+		await indexedWith(store, "s1", [header("ninerelay", "gpt"), message(1, 1, "ninerelay", "gpt", { inputTokens: 100, outputTokens: 0 })], directory.resolveSite);
+		assert.deepEqual(staleAttributions(store, directory), []);
+	});
+});
+
+test("a genuinely direct route is not mistaken for drift", async () => {
+	await withStore(async (store) => {
+		const registry = new RelaySiteRegistry([{ id: "nine", type: "newapi", baseUrl: "https://api.relay-one.example/v1" }]);
+		const providerBaseUrls = { ninerelay: "https://api.relay-one.example/v1", official: "https://api.deepseek.com" };
+		const directory = { available: true, providerBaseUrls, resolveSite: createSiteResolver(registry, providerBaseUrls) };
+		await indexedWith(store, "s1", [header("official", "v4"), message(1, 1, "official", "v4", { inputTokens: 10, outputTokens: 0 })], directory.resolveSite);
+		assert.deepEqual(staleAttributions(store, directory), []);
+	});
+});
+
+test("a directory that could not be read proves nothing about the index", async () => {
+	// Discovery being down makes every route look unresolvable. Acting on that
+	// would rebuild the whole index into a worse state than it started in.
+	await withStore(async (store) => {
+		const directory = liveDirectory();
+		await indexedWith(store, "s1", [header("ninerelay", "gpt"), message(1, 1, "ninerelay", "gpt", { inputTokens: 100, outputTokens: 0 })], directory.resolveSite);
+		assert.deepEqual(staleAttributions(store, { ...directory, available: false }), []);
+		assert.deepEqual(staleAttributions(store, undefined), []);
+	});
+});
+
+test("rows with no route at all are left alone", async () => {
+	// `provider = unknown` has nothing to resolve; it is already counted by the
+	// unattributed diagnostic and must not drive a rebuild that cannot fix it.
+	await withStore(async (store) => {
+		await indexedWith(store, "s1", [message(1, 1, undefined, undefined, { inputTokens: 10, outputTokens: 0 })], liveDirectory().resolveSite);
+		assert.deepEqual(staleAttributions(store, liveDirectory()), []);
 	});
 });
 

--- a/test/store.test.js
+++ b/test/store.test.js
@@ -201,6 +201,24 @@ test("zero-valued route buckets are not persisted", () => {
 	});
 });
 
+test("distinctRoutes is one row per route, not per unit of traffic", () => {
+	// It runs on every sweep, so its size has to track the number of routes ever
+	// seen rather than how much went through them.
+	withStore((store) => {
+		const state = { days: new Map(), lastSample: null, currentRoute: null, consumedSeq: -1 };
+		applyUsageDelta(state, [
+			message(1, 1, "deepseek", "v4", usage(100, 10), DAY_A),
+			message(2, 2, "deepseek", "v4", usage(200, 20), DAY_B),
+			message(3, 3, "deepseek", "v4-mini", usage(5, 1), DAY_B)
+		]);
+		store.commitSession("s1", state, {});
+
+		// node:sqlite hands back null-prototype rows, so compare the fields.
+		const routes = store.distinctRoutes().map((r) => ({ site: r.site, provider: r.provider }));
+		assert.deepEqual(routes, [{ site: "direct", provider: "deepseek" }], "three days and two models, one route");
+	});
+});
+
 test("diagnostics report counts and identifiers only", () => {
 	withStore((store) => {
 		const state = { days: new Map(), lastSample: null, currentRoute: null, consumedSeq: -1 };


### PR DESCRIPTION
Closes #40。**用户的数据直接给出了答案**，不用再猜：

```
── 路由归属（当前配置）──
  api99  https://api.9zyx.xyz/v1  api.9zyx.xyz     ← 今天解析得好好的
  ooioo  https://ooioo.work/v1    ooioo.work       ← 今天解析得好好的

── 索引里的路由（历史流量实际记在哪）──
  直连/官方   ooioo              229,256           ← 同一条路由
  ooioo.work  ooioo               46,514           ← 同一条路由
  直连/官方   api99               30,781
```

## 根因

折叠是**增量**的。`readFrom(id, consumedSeq + 1)` 只追加新事件，所以一个在目录还不认识某条路由时就折叠过的会话，**旧行会永远保留当时的归属**，而它后来的事件归属正确。同一条路由于是同时挂在两个站点下。

而重建的触发条件只看 origin 集合变没变：

```js
const moved = directoryKnown && originKey(next) !== originKey(directory);
```

这能抓到"加了/删了一个中转站"，完全抓不到这一种——**集合一旦稳定，陈旧的行再也不会被重新审视**，哪怕它们和目录明显矛盾。而且 `directoryKnown &&` 让第一次刷新永远不触发重建。

## 改法：直接检查这个矛盾

每次扫描问一遍：索引里记着的每条路由，resolver 今天会把它归到哪？有一条对不上就重建。

查询是 `SELECT DISTINCT site, provider`，**行数是"见过多少条路由"级别，不是流量级别**，所以每次扫描都跑得起。

三条性质，都有测试：

- **自限。** 重建之后存储与 resolver 一致，不会再触发——*一个总是触发的检查就是套着修复外衣的重建循环*。
- **顺带纠正历史。** 以前被错标成 `direct` 的未知路由会变成 `unrouted`。
- **discovery 不可用时完全跳过。** 那时每条路由都"解析不了"，照着重建等于把索引搞得比原来更糟。

## 实测这个修复能治好用户那份数据

```
before — one route under two sites:
  unrouted         260037
  ooioo.work        46514

stale rows detected: [{"site":"unrouted","provider":"api99"},{"site":"unrouted","provider":"ooioo"}]

after the rebuild:
  ooioo.work       275770
  api.9zyx.xyz      30781

stale rows now: []
```

410 全绿。