### PR TITLE
修正官方路由归属、模型总量与最近用量时间

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -1048,6 +1048,13 @@ window.__ModuleLoader__.load({
 		const MODEL_COLUMNS = [
 			{ id: "model", label: "table.model", get: (m) => m.model, numeric: false },
 			{ id: "requests", label: "table.requests", get: (m) => m.requests ?? 0 },
+			{
+				id: "tokens",
+				label: "table.total",
+				get: (m) =>
+					m.tokens ??
+					(m.inputTokens ?? 0) + (m.cacheReadTokens ?? 0) + (m.cacheWriteTokens ?? 0) + (m.outputTokens ?? 0)
+			},
 			{ id: "inputTokens", label: "table.input", get: (m) => m.inputTokens ?? 0 },
 			{ id: "cacheReadTokens", label: "table.cache", get: (m) => m.cacheReadTokens ?? 0 },
 			{ id: "outputTokens", label: "table.output", get: (m) => m.outputTokens ?? 0 },
@@ -1056,7 +1063,7 @@ window.__ModuleLoader__.load({
 
 		/** Same columns as the text report, so the two cannot disagree. */
 		function ModelTable({ data, translate }) {
-			const [sort, setSort] = react.useState({ by: "inputTokens", desc: true });
+			const [sort, setSort] = react.useState({ by: "tokens", desc: true });
 			const priced = new Map((data.priced?.rows ?? []).map((r) => [r.model, r]));
 			const rows = (data.models ?? []).map((m) => ({ ...m, ...priced.get(m.model) }));
 			if (rows.length === 0) return jsx("p", { className: S.note, children: translate("table.none") });
@@ -1100,6 +1107,7 @@ window.__ModuleLoader__.load({
 									children: [
 										jsx("td", { title: m.model, children: m.model }),
 										jsx("td", { children: fmt(m.requests) }),
+										jsx("td", { children: fmt(MODEL_COLUMNS[2].get(m)) }),
 										jsx("td", { children: fmt(m.inputTokens) }),
 										jsxs("td", {
 											children: [
@@ -1420,10 +1428,10 @@ window.__ModuleLoader__.load({
 						title: typeof checked === "number" ? new Date(checked).toLocaleString() : "",
 						children: translate("footer.updated", { ago: agoLabel(checked, translate) })
 					}),
-					typeof d.lastUpdatedAt === "number"
+					typeof d.lastUsageAt === "number"
 						? jsx("span", {
-								title: new Date(d.lastUpdatedAt).toLocaleString(),
-								children: ` · ${translate("footer.lastActivity", { ago: agoLabel(d.lastUpdatedAt, translate) })}`
+								title: new Date(d.lastUsageAt).toLocaleString(),
+								children: ` · ${translate("footer.lastActivity", { ago: agoLabel(d.lastUsageAt, translate) })}`
 							})
 						: null,
 					d.unattributedRows > 0
@@ -1693,6 +1701,7 @@ window.__ModuleLoader__.load({
 			"activity.more": "多",
 			"table.model": "模型",
 			"table.requests": "请求",
+			"table.total": "总计",
 			"table.input": "输入",
 			"table.cache": "缓存",
 			"table.output": "输出",
@@ -1788,6 +1797,7 @@ window.__ModuleLoader__.load({
 			"activity.more": "More",
 			"table.model": "Model",
 			"table.requests": "Req",
+			"table.total": "Total",
 			"table.input": "Input",
 			"table.cache": "Cache",
 			"table.output": "Output",

--- a/src/discovery.js
+++ b/src/discovery.js
@@ -78,7 +78,7 @@ export function readAtPath(section, path = []) {
  *   `providers` is `listConfigurableProviders()`'s array; `readSection(ns)`
  *   returns a resolved settings section (or undefined); `officialOrigins` names
  *   origins that are the vendor's own endpoint and therefore not a relay.
- * @returns `{ sites, providerBaseUrls, skipped }`. `sites` carries one entry
+ * @returns `{ sites, providerBaseUrls, directProviders, skipped }`. `sites` carries one entry
  *   per distinct origin, each listing the routes that reach it. `skipped`
  *   counts routes whose base URL could not be resolved — the honest reason a
  *   relay might be missing from a report.
@@ -107,6 +107,7 @@ export function discoverSites(options = {}) {
 
 	const byOrigin = new Map();
 	const providerBaseUrls = {};
+	const directProviders = [];
 	let skipped = 0;
 
 	for (const entry of providers) {
@@ -116,9 +117,17 @@ export function discoverSites(options = {}) {
 		const profile = readAtPath(sectionFor(entry.settingsNs), entry.settingsPath ?? []);
 		const baseUrl = profile?.baseURL ?? profile?.baseUrl;
 		if (typeof baseUrl !== "string" || baseUrl === "") {
-			// A catalog route with no configured endpoint is the vendor's own
-			// default — direct traffic, not a site. Not an error, but counted so a
-			// missing relay has a number behind it rather than a shrug.
+			// A shipped catalog route with no override uses its vendor default. Keep
+			// the route in the directory as explicitly direct; dropping it here made
+			// the resolver later mistake that known official route for an unknown one.
+			const builtInDeepSeek =
+				route === "deepseek-official" && entry.settingsNs === "llm-deepseek" && entry.settingsPath?.length === 0;
+			if (entry.declared === false || builtInDeepSeek) {
+				directProviders.push(route);
+				continue;
+			}
+			// A user-declared route without a readable profile proves neither direct
+			// nor relay traffic, so leave it unresolved and make the omission visible.
 			skipped++;
 			continue;
 		}
@@ -148,7 +157,7 @@ export function discoverSites(options = {}) {
 		}
 	}
 
-	return { sites: [...byOrigin.values()], providerBaseUrls, skipped };
+	return { sites: [...byOrigin.values()], providerBaseUrls, directProviders, skipped };
 }
 
 /**
@@ -169,14 +178,14 @@ export function discoverFromContext(ctx, options = {}) {
 	const llm = typeof ctx?.get === "function" ? ctx.get("llm") : undefined;
 	const settings = typeof ctx?.get === "function" ? ctx.get("settings") : undefined;
 	if (llm === undefined || settings === undefined) {
-		return { sites: [], providerBaseUrls: {}, skipped: 0, available: false };
+		return { sites: [], providerBaseUrls: {}, directProviders: [], skipped: 0, available: false };
 	}
 
 	let providers;
 	try {
 		providers = llm.listConfigurableProviders?.() ?? [];
 	} catch {
-		return { sites: [], providerBaseUrls: {}, skipped: 0, available: false };
+		return { sites: [], providerBaseUrls: {}, directProviders: [], skipped: 0, available: false };
 	}
 
 	return {
@@ -217,14 +226,16 @@ export function withKnownSoftware(sites = [], known = new Map()) {
  *
  * @param discovered - {@link discoverSites}' result.
  * @param manual - the normalized `relays` config.
- * @returns `{ sites, providerBaseUrls }` ready for a site registry.
+ * @returns `{ sites, providerBaseUrls, directProviders }` ready for a site registry.
  */
 export function mergeSites(discovered = {}, manual = {}) {
 	const sites = new Map();
 	for (const site of discovered.sites ?? []) sites.set(site.id, site);
 	for (const site of manual.sites ?? []) sites.set(site.id, { ...sites.get(site.id), ...site, discovered: false });
+	const providerBaseUrls = { ...(discovered.providerBaseUrls ?? {}), ...(manual.providerBaseUrls ?? {}) };
 	return {
 		sites: [...sites.values()],
-		providerBaseUrls: { ...(discovered.providerBaseUrls ?? {}), ...(manual.providerBaseUrls ?? {}) }
+		providerBaseUrls,
+		directProviders: (discovered.directProviders ?? []).filter((route) => !(route in providerBaseUrls))
 	};
 }

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -185,10 +185,10 @@ export function normalizeRelayConfig(config = {}) {
  *   attributes everything to `direct` and still produces a correct per-model
  *   report.
  */
-export function buildResolver({ sites = [], providerBaseUrls = {} } = {}) {
-	if (sites.length === 0) return undefined;
+export function buildResolver({ sites = [], providerBaseUrls = {}, directProviders = [] } = {}) {
+	if (sites.length === 0 && Object.keys(providerBaseUrls).length === 0 && directProviders.length === 0) return undefined;
 	const registry = new RelaySiteRegistry(sites.map((s) => ({ ...s, type: s.type ?? SITE_TYPES[0] })));
-	return createSiteResolver(registry, providerBaseUrls);
+	return createSiteResolver(registry, providerBaseUrls, directProviders);
 }
 
 /**
@@ -624,7 +624,7 @@ export function apply(ctx, userConfig = {}) {
 	// inherits the property that makes sweeping the right shape for this whole
 	// plugin: it is idempotent and self-healing, so a missed notification costs
 	// one interval rather than a permanently stale answer.
-	let directory = { sites: [], providerBaseUrls: {}, resolveSite: undefined };
+	let directory = { sites: [], providerBaseUrls: {}, directProviders: [], resolveSite: undefined };
 	let directoryKnown = false;
 	// Which relay program each site runs. Its own module, because it is four
 	// pieces of state and a lifecycle — see `fingerprints.js` for why none of
@@ -657,7 +657,7 @@ export function apply(ctx, userConfig = {}) {
 		} catch (error) {
 			// A host that cannot be asked leaves the manual config in charge.
 			logger?.warn?.("tokenledger: could not read the provider directory: %s", error?.message ?? error);
-			discovered = { sites: [], providerBaseUrls: {}, skipped: 0, available: false };
+			discovered = { sites: [], providerBaseUrls: {}, directProviders: [], skipped: 0, available: false };
 		}
 		const merged = mergeSites(discovered, normalizeRelayConfig(config));
 		merged.sites = withKnownSoftware(merged.sites, fingerprints.software);

--- a/src/relay-sites.js
+++ b/src/relay-sites.js
@@ -149,6 +149,8 @@ export class RelaySiteRegistry {
  * @param registry - the relay-site registry.
  * @param providerBaseUrls - `Map<providerId, baseUrl>` or a plain object,
  *   describing how each DSH provider route is currently configured.
+ * @param directProviders - provider ids whose shipped default is known to call
+ *   the vendor directly even though it has no configured base URL.
  * @returns `(providerId) => siteId | DIRECT | undefined`. A site id means the
  *   route points at a known relay; `DIRECT` means the route is configured and
  *   points at no relay, so the call went straight to the vendor; `undefined`
@@ -159,15 +161,20 @@ export class RelaySiteRegistry {
  *   merging them put relay traffic under "direct/official" on a real install
  *   whenever a route had since been renamed or removed.
  */
-export function createSiteResolver(registry, providerBaseUrls) {
+export function createSiteResolver(registry, providerBaseUrls, directProviders = []) {
 	const lookup =
 		providerBaseUrls instanceof Map ? providerBaseUrls : new Map(Object.entries(providerBaseUrls ?? {}));
+	const direct = directProviders instanceof Set ? directProviders : new Set(directProviders);
 	const cache = new Map();
 	return (providerId) => {
 		if (cache.has(providerId)) return cache.get(providerId);
 		// Presence in the directory is the thing being asked, so it is checked
 		// before the origin match rather than inferred from its failure.
-		const answer = lookup.has(providerId) ? (registry.matchOrigin(lookup.get(providerId))?.id ?? DIRECT) : undefined;
+		const answer = direct.has(providerId)
+			? DIRECT
+			: lookup.has(providerId)
+				? (registry.matchOrigin(lookup.get(providerId))?.id ?? DIRECT)
+				: undefined;
 		cache.set(providerId, answer);
 		return answer;
 	};

--- a/src/store.js
+++ b/src/store.js
@@ -30,7 +30,7 @@ import { DatabaseSync } from "node:sqlite";
 
 import { createUsageState, totalTokens, cacheHitRate, parseRouteKey, routeKey, zeroBuckets } from "./usage.js";
 
-export const SCHEMA_VERSION = 2;
+export const SCHEMA_VERSION = 3;
 
 const COLUMNS = [
 	"inputTokens",
@@ -90,6 +90,7 @@ CREATE TABLE IF NOT EXISTS checkpoints (
   logRevision  TEXT,
   cursor       TEXT NOT NULL,
   dshVersion   TEXT,
+  lastUsageAt  INTEGER,
   updatedAt    INTEGER NOT NULL
 ) WITHOUT ROWID;
 `;
@@ -173,9 +174,8 @@ export class LedgerStore {
 		if (version !== SCHEMA_VERSION) {
 			// The index is disposable by design, so a version mismatch is discarded
 			// rather than migrated. The logs it was built from are untouched.
-			this.#db.exec("DELETE FROM session_rollups");
-			this.#db.exec("DELETE FROM sessions");
-			this.#db.exec("DELETE FROM checkpoints");
+			this.#db.exec("DROP TABLE IF EXISTS session_rollups; DROP TABLE IF EXISTS sessions; DROP TABLE IF EXISTS checkpoints;");
+			this.#db.exec(SCHEMA);
 			this.#db.prepare("UPDATE meta SET value = ? WHERE key = 'schemaVersion'").run(String(SCHEMA_VERSION));
 		}
 	}
@@ -194,13 +194,14 @@ export class LedgerStore {
 		);
 		this.#stmt.deleteSession = this.#db.prepare("DELETE FROM sessions WHERE sessionId = ?");
 		this.#stmt.upsertCheckpoint = this.#db.prepare(
-			`INSERT INTO checkpoints (sessionId, consumedSeq, logRevision, cursor, dshVersion, updatedAt)
-			 VALUES (?, ?, ?, ?, ?, ?)
+			`INSERT INTO checkpoints (sessionId, consumedSeq, logRevision, cursor, dshVersion, lastUsageAt, updatedAt)
+			 VALUES (?, ?, ?, ?, ?, ?, ?)
 			 ON CONFLICT (sessionId) DO UPDATE SET
 			   consumedSeq = excluded.consumedSeq,
 			   logRevision = excluded.logRevision,
 			   cursor      = excluded.cursor,
 			   dshVersion  = excluded.dshVersion,
+			   lastUsageAt = excluded.lastUsageAt,
 			   updatedAt   = excluded.updatedAt`
 		);
 		this.#stmt.deleteCheckpoint = this.#db.prepare("DELETE FROM checkpoints WHERE sessionId = ?");
@@ -234,6 +235,7 @@ export class LedgerStore {
 			consumedSeq: Number(row.consumedSeq),
 			logRevision: row.logRevision ?? undefined,
 			dshVersion: row.dshVersion ?? undefined,
+			lastUsageAt: row.lastUsageAt === null ? undefined : Number(row.lastUsageAt),
 			updatedAt: Number(row.updatedAt)
 		};
 	}
@@ -245,6 +247,7 @@ export class LedgerStore {
 			consumedSeq: Number(row.consumedSeq),
 			logRevision: row.logRevision ?? undefined,
 			dshVersion: row.dshVersion ?? undefined,
+			lastUsageAt: row.lastUsageAt === null ? undefined : Number(row.lastUsageAt),
 			updatedAt: Number(row.updatedAt)
 		}));
 	}
@@ -275,6 +278,7 @@ export class LedgerStore {
 		state.consumedSeq = Number(checkpoint.consumedSeq);
 		state.lastSample = cursor.lastSample ?? null;
 		state.currentRoute = cursor.currentRoute ?? null;
+		state.lastUsageAt = checkpoint.lastUsageAt === null ? undefined : Number(checkpoint.lastUsageAt);
 		return state;
 	}
 
@@ -314,6 +318,7 @@ export class LedgerStore {
 				options.logRevision ?? null,
 				cursor,
 				options.dshVersion ?? null,
+				state.lastUsageAt ?? null,
 				updatedAt
 			);
 		});
@@ -453,7 +458,8 @@ export class LedgerStore {
 				   (SELECT COUNT(*) FROM checkpoints)                  AS sessionsTracked,
 				   (SELECT MIN(day) FROM session_rollups)              AS firstDay,
 				   (SELECT MAX(day) FROM session_rollups)              AS lastDay,
-				   (SELECT MAX(updatedAt) FROM checkpoints)            AS lastUpdatedAt`
+				   (SELECT MAX(lastUsageAt) FROM checkpoints)           AS lastUsageAt,
+				   (SELECT MAX(updatedAt) FROM checkpoints)             AS lastUpdatedAt`
 			)
 			.get();
 		const unknownRoutes = this.#db
@@ -466,6 +472,7 @@ export class LedgerStore {
 			sessionsTracked: Number(counts.sessionsTracked),
 			firstDay: counts.firstDay ?? undefined,
 			lastDay: counts.lastDay ?? undefined,
+			lastUsageAt: counts.lastUsageAt === null ? undefined : Number(counts.lastUsageAt),
 			lastUpdatedAt: counts.lastUpdatedAt === null ? undefined : Number(counts.lastUpdatedAt),
 			unattributedRows: Number(unknownRoutes.n)
 		};

--- a/src/usage.js
+++ b/src/usage.js
@@ -278,7 +278,7 @@ function routeBucketOf(entry, key) {
  * stays exact without replaying the whole log.
  */
 export function createUsageState() {
-	return { days: new Map(), lastSample: null, currentRoute: null, consumedSeq: -1 };
+	return { days: new Map(), lastSample: null, currentRoute: null, lastUsageAt: undefined, consumedSeq: -1 };
 }
 
 /**
@@ -307,6 +307,9 @@ export function applyUsageDelta(state, events, options = {}) {
 
 		const sample = sampleOf(event);
 		if (sample === undefined) continue;
+		if (typeof event.time === "number" && Number.isFinite(event.time)) {
+			state.lastUsageAt = Math.max(state.lastUsageAt ?? -Infinity, event.time);
+		}
 
 		const provenance = provenanceOf(event) ?? currentRoute;
 		const provider = provenance?.provider ?? UNKNOWN;

--- a/test/client.test.js
+++ b/test/client.test.js
@@ -545,6 +545,8 @@ test("the model table carries request counts, so a hit rate can be read", async 
 	assert.ok(text.includes("40.3%"));
 	assert.ok(text.includes("11.7%"));
 	assert.ok(text.includes("27,492"));
+	assert.ok(text.includes("30,781"), "total reconciles input, cache and output with the site row");
+	assert.ok(text.includes("table.total"));
 });
 
 test("a relay whose software is unrecognised gets one honest line, not an empty card", async () => {
@@ -1161,7 +1163,7 @@ test("the footer says nothing about an index", async () => {
 	}
 });
 
-test("freshness reports when the logs were READ, not when they last changed", async () => {
+test("freshness reports when logs were read while activity uses the event time", async () => {
 	// The checkpoint table only advances on a session that moved, so after a
 	// quiet half hour it sat half an hour behind while the figures were exactly
 	// right — reported as freshness, that reads as a stuck panel, and it was
@@ -1172,7 +1174,11 @@ test("freshness reports when the logs were READ, not when they last changed", as
 		render(exports.Footer, {
 			data: {
 				lastSweepAt: now - 4_000,
-				diagnostics: { lastUpdatedAt: now - 35 * 60_000, unattributedRows: 0 }
+				diagnostics: {
+					lastUpdatedAt: now - 2_000,
+					lastUsageAt: now - 35 * 60_000,
+					unattributedRows: 0
+				}
 			},
 			translate: T
 		})

--- a/test/discovery.test.js
+++ b/test/discovery.test.js
@@ -85,13 +85,22 @@ test("the credential sitting beside the base URL is never read", () => {
 	assert.deepEqual(Object.keys(result.sites[0]).sort(), ["baseUrl", "declared", "discovered", "id", "routes"]);
 });
 
-test("a route with no configured endpoint is direct traffic, and is counted rather than shrugged at", () => {
-	const { sites, skipped } = discoverSites({
-		providers: [piAi("deepseek-official", false), piAi("relay", true)],
+test("a shipped route with no configured endpoint stays known as direct traffic", () => {
+	const { sites, directProviders, skipped } = discoverSites({
+		providers: [
+			{
+				provider: "deepseek-official",
+				displayName: "DeepSeek",
+				settingsNs: "llm-deepseek",
+				settingsPath: []
+			},
+			piAi("relay", true)
+		],
 		readSection: () => section({ relay: { baseURL: "https://relay.example/v1" } })
 	});
 	assert.equal(sites.length, 1);
-	assert.equal(skipped, 1, "a missing relay must have a number behind it");
+	assert.deepEqual(directProviders, ["deepseek-official"]);
+	assert.equal(skipped, 0, "a known vendor default is resolved, not skipped");
 });
 
 test("an unparseable base URL is skipped, not turned into a site named after garbage", () => {
@@ -186,7 +195,13 @@ test("an llm service that throws degrades instead of taking the plugin down", ()
 					}
 				: { get: () => ({}) }
 	};
-	assert.deepEqual(discoverFromContext(ctx), { sites: [], providerBaseUrls: {}, skipped: 0, available: false });
+	assert.deepEqual(discoverFromContext(ctx), {
+		sites: [],
+		providerBaseUrls: {},
+		directProviders: [],
+		skipped: 0,
+		available: false
+	});
 });
 
 // --- merging ----------------------------------------------------------------
@@ -212,7 +227,15 @@ test("merging keeps the discovered route map and lets manual entries win per rou
 });
 
 test("merging nothing with nothing is not an error", () => {
-	assert.deepEqual(mergeSites(), { sites: [], providerBaseUrls: {} });
+	assert.deepEqual(mergeSites(), { sites: [], providerBaseUrls: {}, directProviders: [] });
+});
+
+test("a manual relay override wins over a shipped direct default", () => {
+	const merged = mergeSites(
+		{ sites: [], providerBaseUrls: {}, directProviders: ["deepseek-official"] },
+		{ sites: [], providerBaseUrls: { "deepseek-official": "https://relay.example/v1" } }
+	);
+	assert.deepEqual(merged.directProviders, []);
 });
 
 test("a fingerprint result survives the directory being rebuilt", () => {

--- a/test/plugin.test.js
+++ b/test/plugin.test.js
@@ -1,9 +1,10 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { normalizeRelayConfig, staleAttributions, sweep } from "../src/plugin.js";
+import { buildResolver, normalizeRelayConfig, staleAttributions, sweep } from "../src/plugin.js";
 import { LedgerStore } from "../src/store.js";
 import { RelaySiteRegistry, createSiteResolver } from "../src/relay-sites.js";
+import { DIRECT } from "../src/usage.js";
 
 const DAY = Date.parse("2026-08-14T10:00:00");
 let seq = 0;
@@ -320,6 +321,12 @@ test("no relays configured means no resolver, and everything is direct", async (
 		await sweep(fakePersistence(sessions), store, { resolveSite });
 		assert.deepEqual(store.bySite().map((s) => s.site), ["direct"], "still a correct report, just no site dimension");
 	});
+});
+
+test("a shipped provider default resolves as official even without a relay site", () => {
+	const resolveSite = buildResolver({ directProviders: ["deepseek-official"] });
+	assert.equal(resolveSite("deepseek-official"), DIRECT);
+	assert.equal(resolveSite("removed-route"), undefined, "an absent route remains unknown");
 });
 
 test("a malformed relay entry is skipped rather than poisoning the map", async () => {

--- a/test/store.test.js
+++ b/test/store.test.js
@@ -1,8 +1,12 @@
 import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { DatabaseSync } from "node:sqlite";
 import test from "node:test";
 
 import { LedgerStore } from "../src/store.js";
-import { applyUsageDelta } from "../src/usage.js";
+import { applyUsageDelta, createUsageState } from "../src/usage.js";
 import { RelaySiteRegistry, createSiteResolver } from "../src/relay-sites.js";
 
 const DAY_A = Date.parse("2026-08-14T10:00:00");
@@ -229,12 +233,14 @@ test("diagnostics report counts and identifiers only", () => {
 		store.commitSession("s1", state, { dshVersion: "0.1.0-rc.6" });
 
 		const d = store.diagnostics();
-		assert.equal(d.schemaVersion, 2);
+		assert.equal(d.schemaVersion, 3);
 		assert.equal(d.sessionsTracked, 1);
 		assert.equal(d.sessionsWithUsage, 1);
 		assert.equal(d.firstDay, "2026-08-14");
 		assert.equal(d.lastDay, "2026-08-15");
+		assert.equal(d.lastUsageAt, DAY_B, "last usage comes from the event timestamp");
 		assert.equal(d.unattributedRows, 1, "the header-less sample is visible as unattributed");
+		assert.equal(store.checkpointFor("s1").lastUsageAt, DAY_B, "the event timestamp survives a restart");
 		assert.equal(store.checkpointFor("s1").dshVersion, "0.1.0-rc.6");
 		assert.equal(JSON.stringify(d).includes("prompt"), false);
 	});
@@ -253,17 +259,34 @@ test("csv export quotes cells that need it", () => {
 	});
 });
 
-test("a schema version bump discards the index rather than migrating it", () => {
-	const store = LedgerStore.open(":memory:");
-	const state = { days: new Map(), lastSample: null, currentRoute: null, consumedSeq: -1 };
-	applyUsageDelta(state, [message(1, 1, "deepseek", "v4", usage(100, 10))]);
-	store.commitSession("s1", state);
-	assert.equal(store.totals().inputTokens, 100);
-	store.close();
-	// A real bump is exercised by the migrate path on open; here we assert the
-	// contract the path relies on: the index is reconstructible from nothing.
-	const fresh = LedgerStore.open(":memory:");
-	assert.equal(fresh.totals().inputTokens, 0);
-	assert.equal(fresh.diagnostics().rollupRows, 0);
-	fresh.close();
+test("opening a v2 database rebuilds the disposable index with the v3 checkpoint shape", () => {
+	const dir = mkdtempSync(join(tmpdir(), "tokenledger-schema-"));
+	const path = join(dir, "ledger.sqlite");
+	try {
+		const seeded = LedgerStore.open(path);
+		const state = createUsageState();
+		applyUsageDelta(state, [message(1, 1, "deepseek", "v4", usage(100, 10))]);
+		seeded.commitSession("s1", state);
+		seeded.close();
+
+		const old = new DatabaseSync(path);
+		old.exec(`
+			DROP TABLE checkpoints;
+			CREATE TABLE checkpoints (
+			  sessionId TEXT PRIMARY KEY, consumedSeq INTEGER NOT NULL, logRevision TEXT,
+			  cursor TEXT NOT NULL, dshVersion TEXT, updatedAt INTEGER NOT NULL
+			) WITHOUT ROWID;
+			UPDATE meta SET value = '2' WHERE key = 'schemaVersion';
+		`);
+		old.prepare("INSERT INTO checkpoints VALUES (?, ?, ?, ?, ?, ?)").run("s1", 1, "r1", "{}", null, DAY_A);
+		old.close();
+
+		const migrated = LedgerStore.open(path);
+		assert.equal(migrated.diagnostics().schemaVersion, 3);
+		assert.equal(migrated.diagnostics().rollupRows, 0, "old projections are rebuilt from logs instead of altered in place");
+		assert.equal(migrated.checkpointFor("s1"), undefined);
+		migrated.close();
+	} finally {
+		rmSync(dir, { recursive: true, force: true });
+	}
 });

--- a/test/usage.test.js
+++ b/test/usage.test.js
@@ -148,6 +148,7 @@ test("a replacement that lands on the next day unwinds the first day", () => {
 	assert.equal(state.days.get("2026-08-14").totals.requests, 0, "the superseded day is emptied");
 	assert.equal(state.days.get("2026-08-14").totals.outputTokens, 0);
 	assert.equal(state.days.get("2026-08-15").totals.outputTokens, 50);
+	assert.equal(state.lastUsageAt, DAY_B, "activity time follows the usage event, not the fold time");
 });
 
 test("consumedSeq advances so a caller can checkpoint", () => {


### PR DESCRIPTION
## 变更

- 将无 baseURL 覆盖的内置 DeepSeek provider 识别为直连/官方，同时保留真正缺失路由的未知状态
- 在模型表增加总计列，让输入、缓存、输出可与站点总量直接核对
- 持久化 usage 事件时间，页脚的最近一次用量不再使用索引更新时间
- 升级可丢弃索引 schema，并加入 v2 到 v3 的重建回归

## 验证

- npm test（412 项）
- npm pack --dry-run
- 本地 DSH + Playwright 真实浏览器回归

Closes #42