### PR TITLE
Fix forked sessions double-counting inherited usage

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -237,7 +237,15 @@ export async function sweep(persistence, store, options = {}) {
 			}
 
 			const state = store.loadState(sessionId);
-			const { events } = await persistence.readFrom(sessionId, state.consumedSeq + 1);
+			// A fork's durable log starts with a copy of its parent's event prefix.
+			// DSH records the exclusive end of that inherited prefix as seedLength.
+			// Counting it again under the child's session id makes every fork inflate
+			// the ledger. Existing checkpoints already point past the prefix; only a
+			// session's first read needs to start at the durable seed boundary.
+			const fromSeq = checkpoint === undefined
+				? (snapshot.header?.seedLength ?? 0)
+				: state.consumedSeq + 1;
+			const { events } = await persistence.readFrom(sessionId, fromSeq);
 			if ((events?.length ?? 0) === 0) {
 				stats.skipped++;
 				continue;

--- a/src/store.js
+++ b/src/store.js
@@ -30,7 +30,7 @@ import { DatabaseSync } from "node:sqlite";
 
 import { createUsageState, totalTokens, cacheHitRate, parseRouteKey, routeKey, zeroBuckets } from "./usage.js";
 
-export const SCHEMA_VERSION = 3;
+export const SCHEMA_VERSION = 4;
 
 const COLUMNS = [
 	"inputTokens",
@@ -254,8 +254,9 @@ export class LedgerStore {
 
 	/**
 	 * Rehydrate a session's fold state so the next slice of events can be applied
-	 * incrementally. Returns a fresh state when the session is unknown, which is
-	 * what makes `readFrom(id, 0)` the natural rebuild.
+	 * incrementally. Returns a fresh state when the session is unknown; the sweep
+	 * then chooses seq 0 for a fresh session or the durable seed boundary for a
+	 * fork whose leading events belong to its parent.
 	 */
 	loadState(sessionId) {
 		const state = createUsageState();
@@ -334,9 +335,9 @@ export class LedgerStore {
 	}
 
 	/**
-	 * Discard the whole index. The next collection pass rebuilds it from
-	 * `readFrom(id, 0)`. This is the supported rebuild entry point, not a
-	 * last-resort repair.
+	 * Discard the whole index. The next collection pass rebuilds each session
+	 * from its non-inherited boundary. This is the supported rebuild entry point,
+	 * not a last-resort repair.
 	 */
 	reset() {
 		this.#transaction(() => {

--- a/test/plugin.test.js
+++ b/test/plugin.test.js
@@ -12,6 +12,16 @@ const ev = (type, data) => ({ type, seq: seq++, time: DAY, data });
 const header = (provider, model) => ev("request/header", { header: { config: { provider, model } } });
 const message = (turn, step, provider, model, usage) =>
 	ev("assistant/message", { turn, step, message: { role: "assistant", source: { kind: "model", provider, model } }, usage });
+const eventAt = (seq, type, data) => ({ type, seq, time: DAY, data });
+const headerAt = (seq) => eventAt(seq, "request/header", { header: { config: { provider: "p", model: "m" } } });
+const messageAt = (seq, turn, inputTokens, outputTokens = 0) =>
+	eventAt(seq, "assistant/message", {
+		turn,
+		step: 1,
+		message: { role: "assistant", source: { kind: "model", provider: "p", model: "m" } },
+		usage: { inputTokens, outputTokens }
+	});
+const seedEndAt = (seq) => eventAt(seq, "session/end-seed", {});
 
 /**
  * A persistence double shaped like the real one: `listSnapshots()` returns
@@ -22,7 +32,7 @@ const message = (turn, step, provider, model, usage) =>
 const fakePersistence = (sessions) => ({
 	async listSnapshots() {
 		return [...sessions.entries()].map(([id, s]) => ({
-			header: { version: 0, id, createdAt: DAY },
+			header: { version: 0, id, createdAt: DAY, ...s.header },
 			revision: s.revision
 		}));
 	},
@@ -110,6 +120,104 @@ test("a changed revision reads only the tail and stays exact", async () => {
 		assert.equal(stats.events, 1, "only the appended event was read");
 		assert.equal(store.totals().inputTokens, 150);
 		assert.equal(store.totals().requests, 2);
+	});
+});
+
+test("a fork counts only usage recorded after its inherited seed", async () => {
+	await withStore(async (store) => {
+		const parentEvents = [headerAt(0), messageAt(1, 1, 100, 10)];
+		const childEvents = [
+			...structuredClone(parentEvents),
+			seedEndAt(2),
+			headerAt(3),
+			messageAt(4, 2, 50, 5)
+		];
+		const sessions = new Map([
+			["parent", { revision: "parent-r1", events: parentEvents }],
+			[
+				"child",
+				{
+					revision: "child-r1",
+					header: { parentSession: "parent", seedLength: parentEvents.length },
+					events: childEvents
+				}
+			]
+		]);
+
+		const stats = await sweep(fakePersistence(sessions), store, {});
+
+		assert.equal(stats.events, 5, "the child's two inherited events are not folded again");
+		assert.equal(store.totals().inputTokens, 150);
+		assert.equal(store.totals().outputTokens, 15);
+		assert.equal(store.totals().requests, 2);
+	});
+});
+
+test("nested forks count each model request exactly once", async () => {
+	await withStore(async (store) => {
+		const parentEvents = [messageAt(0, 1, 100)];
+		const childEvents = [
+			...structuredClone(parentEvents),
+			seedEndAt(1),
+			messageAt(2, 2, 50)
+		];
+		const grandchildEvents = [
+			...structuredClone(childEvents),
+			seedEndAt(3),
+			messageAt(4, 3, 25)
+		];
+		const sessions = new Map([
+			["parent", { revision: "parent-r1", events: parentEvents }],
+			["child", { revision: "child-r1", header: { parentSession: "parent", seedLength: 1 }, events: childEvents }],
+			[
+				"grandchild",
+				{
+					revision: "grandchild-r1",
+					header: { parentSession: "child", seedLength: childEvents.length },
+					events: grandchildEvents
+				}
+			]
+		]);
+
+		await sweep(fakePersistence(sessions), store, {});
+
+		assert.equal(store.totals().inputTokens, 175);
+		assert.equal(store.totals().requests, 3);
+	});
+});
+
+test("a fork resumes incrementally after establishing its seed checkpoint", async () => {
+	await withStore(async (store) => {
+		const inherited = [messageAt(0, 1, 100, 10)];
+		const events = [...structuredClone(inherited), seedEndAt(1)];
+		const sessions = new Map([
+			[
+				"child",
+				{
+					revision: "r1",
+					header: { parentSession: "parent", seedLength: inherited.length },
+					events
+				}
+			]
+		]);
+		const persistence = fakePersistence(sessions);
+		const reads = [];
+		const recording = {
+			...persistence,
+			readFrom: (id, fromSeq) => {
+				reads.push(fromSeq);
+				return persistence.readFrom(id, fromSeq);
+			}
+		};
+
+		await sweep(recording, store, {});
+		events.push(messageAt(2, 2, 50, 5));
+		sessions.get("child").revision = "r2";
+		await sweep(recording, store, {});
+
+		assert.deepEqual(reads, [1, 2]);
+		assert.equal(store.totals().tokens, 55);
+		assert.equal(store.totals().requests, 1);
 	});
 });
 

--- a/test/store.test.js
+++ b/test/store.test.js
@@ -233,7 +233,7 @@ test("diagnostics report counts and identifiers only", () => {
 		store.commitSession("s1", state, { dshVersion: "0.1.0-rc.6" });
 
 		const d = store.diagnostics();
-		assert.equal(d.schemaVersion, 3);
+		assert.equal(d.schemaVersion, 4);
 		assert.equal(d.sessionsTracked, 1);
 		assert.equal(d.sessionsWithUsage, 1);
 		assert.equal(d.firstDay, "2026-08-14");
@@ -259,7 +259,7 @@ test("csv export quotes cells that need it", () => {
 	});
 });
 
-test("opening a v2 database rebuilds the disposable index with the v3 checkpoint shape", () => {
+test("opening a v2 database rebuilds the disposable index with the v4 checkpoint shape", () => {
 	const dir = mkdtempSync(join(tmpdir(), "tokenledger-schema-"));
 	const path = join(dir, "ledger.sqlite");
 	try {
@@ -282,9 +282,33 @@ test("opening a v2 database rebuilds the disposable index with the v3 checkpoint
 		old.close();
 
 		const migrated = LedgerStore.open(path);
-		assert.equal(migrated.diagnostics().schemaVersion, 3);
+		assert.equal(migrated.diagnostics().schemaVersion, 4);
 		assert.equal(migrated.diagnostics().rollupRows, 0, "old projections are rebuilt from logs instead of altered in place");
 		assert.equal(migrated.checkpointFor("s1"), undefined);
+		migrated.close();
+	} finally {
+		rmSync(dir, { recursive: true, force: true });
+	}
+});
+
+test("opening a v3 database rebuilds projections that may contain duplicated fork seeds", () => {
+	const dir = mkdtempSync(join(tmpdir(), "tokenledger-fork-schema-"));
+	const path = join(dir, "ledger.sqlite");
+	try {
+		const seeded = LedgerStore.open(path);
+		const state = createUsageState();
+		applyUsageDelta(state, [message(1, 1, "deepseek", "v4", usage(100, 10))]);
+		seeded.commitSession("fork-child", state);
+		seeded.close();
+
+		const old = new DatabaseSync(path);
+		old.prepare("UPDATE meta SET value = '3' WHERE key = 'schemaVersion'").run();
+		old.close();
+
+		const migrated = LedgerStore.open(path);
+		assert.equal(migrated.diagnostics().schemaVersion, 4);
+		assert.equal(migrated.diagnostics().rollupRows, 0, "v3 projections are rebuilt from the seed-aware boundary");
+		assert.equal(migrated.checkpointFor("fork-child"), undefined);
 		migrated.close();
 	} finally {
 		rmSync(dir, { recursive: true, force: true });


### PR DESCRIPTION
## Summary

- start a forked session's first usage sweep at the durable `header.seedLength` boundary
- keep existing checkpoints incremental after that first seed-aware read
- bump the disposable SQLite index to schema v4 so existing duplicated rollups rebuild automatically
- cover direct forks, nested forks, incremental follow-up sweeps, and v3 index rebuilding

## Verification

- `npm test` — 416 tests passed

Fixes #48